### PR TITLE
Fix issue 4 grid motion overlaps with navbar

### DIFF
--- a/src/components/navs/Nav.jsx
+++ b/src/components/navs/Nav.jsx
@@ -24,7 +24,7 @@ const Nav = () => {
   }, []);
 
   return (
-    <Box position={'fixed'} zIndex={1} top={0} left={0} className='main-nav' pl={{base: '1.5em', md: '5em'}} pr={{base: '1.5em', md: '4em'}} w={"100%"} borderBottom={"1px solid #ffffff1c"}>
+    <Box position={'fixed'} zIndex={100} top={0} left={0} className='main-nav' pl={{base: '1.5em', md: '5em'}} pr={{base: '1.5em', md: '4em'}} w={"100%"} borderBottom={"1px solid #ffffff1c"}>
       <Flex h={14} alignItems="center" justifyContent="space-between">
         <Link to="/">
           <Image src={Logo} alt="Logo" height="25px" />


### PR DESCRIPTION
Fix issue #4 

Increased the z-index of the navbar from 1 to 100.

**screenshots:**

![image](https://github.com/user-attachments/assets/e0876be2-15dd-42eb-9fc0-33daf3ac3519)

![image](https://github.com/user-attachments/assets/cbf47fab-237f-47d5-8473-6042c777b50c)

