### PR TITLE
fix: type issue in click-spark component

### DIFF
--- a/src/ts-default/Animations/ClickSpark/ClickSpark.tsx
+++ b/src/ts-default/Animations/ClickSpark/ClickSpark.tsx
@@ -1,4 +1,4 @@
-import React, {useRef, useEffect, useCallback} from "react";
+import React, { useRef, useEffect, useCallback } from "react";
 
 interface ClickSparkProps {
     sparkColor?: string;
@@ -8,6 +8,7 @@ interface ClickSparkProps {
     duration?: number;
     easing?: "linear" | "ease-in" | "ease-out" | "ease-in-out";
     extraScale?: number;
+    children?: React.ReactNode;
 }
 
 interface Spark {
@@ -25,6 +26,7 @@ const ClickSpark: React.FC<ClickSparkProps> = ({
     duration = 400,
     easing = "ease-out",
     extraScale = 1.0,
+    children
 }) => {
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const sparksRef = useRef<Spark[]>([]); // Stores spark data
@@ -137,7 +139,7 @@ const ClickSpark: React.FC<ClickSparkProps> = ({
         };
     }, [sparkColor, sparkSize, sparkRadius, sparkCount, duration, easeFunc, extraScale]);
 
-    const handleClick = (e: React.MouseEvent<HTMLCanvasElement>): void => {
+    const handleClick = (e: React.MouseEvent<HTMLDivElement>): void => {
         const canvas = canvasRef.current;
         if (!canvas) return;
         const rect = canvas.getBoundingClientRect();
@@ -156,16 +158,23 @@ const ClickSpark: React.FC<ClickSparkProps> = ({
     };
 
     return (
-        <canvas
-            ref={canvasRef}
-            style={{
-                width: "100%",
-                height: "100%",
-                display: "block",
-                userSelect: "none"
-            }}
-            onClick={handleClick}
-        />
+        <div style={{
+            width:"100%",
+            height:"100%",
+            position:"relative"
+        }}
+        onClick={handleClick}
+        >
+            <canvas
+                ref={canvasRef}
+                style={{
+                   position:"absolute",
+                   inset:0,
+                   pointerEvents:"none"
+                }}
+            />
+            {children}
+        </div>
     );
 };
 

--- a/src/ts-tailwind/Animations/ClickSpark/ClickSpark.tsx
+++ b/src/ts-tailwind/Animations/ClickSpark/ClickSpark.tsx
@@ -1,4 +1,4 @@
-import React, {useRef, useEffect, useCallback} from "react";
+import React, { useRef, useEffect, useCallback } from "react";
 
 interface ClickSparkProps {
   sparkColor?: string;
@@ -8,6 +8,7 @@ interface ClickSparkProps {
   duration?: number;
   easing?: "linear" | "ease-in" | "ease-out" | "ease-in-out";
   extraScale?: number;
+  children?: React.ReactNode;
 }
 
 interface Spark {
@@ -25,6 +26,7 @@ const ClickSpark: React.FC<ClickSparkProps> = ({
   duration = 400,
   easing = "ease-out",
   extraScale = 1.0,
+    children
 }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const sparksRef = useRef<Spark[]>([]); // Stores spark data
@@ -137,7 +139,7 @@ const ClickSpark: React.FC<ClickSparkProps> = ({
     };
   }, [sparkColor, sparkSize, sparkRadius, sparkCount, duration, easeFunc, extraScale]);
 
-  const handleClick = (e: React.MouseEvent<HTMLCanvasElement>): void => {
+    const handleClick = (e: React.MouseEvent<HTMLDivElement>): void => {
     const canvas = canvasRef.current;
     if (!canvas) return;
     const rect = canvas.getBoundingClientRect();
@@ -155,13 +157,18 @@ const ClickSpark: React.FC<ClickSparkProps> = ({
     sparksRef.current.push(...newSparks);
   };
 
-  return (
-      <canvas
-          ref={canvasRef}
-          className="w-full h-full block select-none"
+    return (
+        <div
+          className="relative w-full h-full"
           onClick={handleClick}
-      />
-  );
+        >
+            <canvas
+                ref={canvasRef}
+                className="absolute inset-0 pointer-events-none"
+            />
+            {children}
+        </div>
+    );
 };
 
 export default ClickSpark;


### PR DESCRIPTION
### Pull Request Description

#### Summary
This pull request enhances the `ClickSpark` component in both `ts-default` and `ts-tailwind` directories by adding support for rendering children elements and improving the component structure.

#### Changes Made
1. **Added `children` prop**: 
    - `ClickSpark` component now accepts a `children` prop of type `React.ReactNode`, allowing nested elements within the component.
2. **Updated component structure**:
    - Replaced the `canvas` element with a `div` wrapper to handle click events and position the canvas absolutely within the div.
    - Adjusted styles to ensure the canvas fills the parent div and does not interfere with pointer events.

#### Detailed Changes
- **`ClickSpark.tsx` (ts-default/Animations/ClickSpark)**:
    - Added `children` prop to `ClickSparkProps`.
    - Updated the `ClickSpark` component to render a `div` containing the `canvas` and children elements.
    - Changed the click event handler to target the `div` instead of the `canvas`.

- **`ClickSpark.tsx` (ts-tailwind/Animations/ClickSpark)**:
    - Added `children` prop to `ClickSparkProps`.
    - Updated the `ClickSpark` component to render a `div` containing the `canvas` and children elements.
    - Changed the click event handler to target the `div` instead of the `canvas`.

#### Benefits
- **Enhanced Flexibility**: Allows developers to nest interactive elements within the `ClickSpark` component.
- **Improved Structure**: Ensures better handling of click events and positioning of elements within the component.

#### Testing
- Ensure that the `ClickSpark` component renders correctly with and without children.
- Verify that the click events trigger the spark animation as expected.
- Test the component's behavior with various combinations of props and nested elements.

## Record Link 
https://www.awesomescreenshot.com/video/36844566?key=2e278f9b98be587f7e9f99c26c99c4e1

