### PR TITLE
[FEAT]: Add transparency support to MetaBalls components

### DIFF
--- a/src/content/Animations/MetaBalls/MetaBalls.jsx
+++ b/src/content/Animations/MetaBalls/MetaBalls.jsx
@@ -74,6 +74,7 @@ uniform int iBallCount;
 uniform float iCursorBallSize;
 uniform vec3 iMetaBalls[50]; // Precomputed: xy = position, z = radius
 uniform float iClumpFactor;
+uniform bool enableTransparency;
 out vec4 outColor;
 const float PI = 3.14159265359;
 
@@ -103,7 +104,7 @@ void main() {
     float alpha2 = m2 / total;
     cFinal = iColor * alpha1 + iCursorColor * alpha2;
   }
-  outColor = vec4(cFinal * f, 1.0);
+  outColor = vec4(cFinal * f, enableTransparency ? f : 1.0);
 }
 `;
 
@@ -117,6 +118,7 @@ const MetaBalls = ({
   clumpFactor = 1,
   cursorBallSize = 3,
   cursorBallColor = "#ffffff",
+  enableTransparency = false,
 }) => {
   const containerRef = useRef(null);
 
@@ -127,7 +129,7 @@ const MetaBalls = ({
     const dpr = 1;
     const renderer = new Renderer({ dpr, alpha: true, premultipliedAlpha: false });
     const gl = renderer.gl;
-    gl.clearColor(0, 0, 0, 0);
+    gl.clearColor(0, 0, 0, enableTransparency ? 0 : 1);
     container.appendChild(gl.canvas);
 
     const camera = new Camera(gl, {
@@ -158,6 +160,7 @@ const MetaBalls = ({
         iCursorBallSize: { value: cursorBallSize },
         iMetaBalls: { value: metaBallsUniform },
         iClumpFactor: { value: clumpFactor },
+        enableTransparency: { value: enableTransparency },
       },
     });
 
@@ -276,6 +279,7 @@ const MetaBalls = ({
     ballCount,
     clumpFactor,
     cursorBallSize,
+    enableTransparency,
   ]);
 
   return <div ref={containerRef} className="metaballs-container" />;

--- a/src/tailwind/Animations/MetaBalls/MetaBalls.jsx
+++ b/src/tailwind/Animations/MetaBalls/MetaBalls.jsx
@@ -72,6 +72,7 @@ uniform int iBallCount;
 uniform float iCursorBallSize;
 uniform vec3 iMetaBalls[50]; // Precomputed: xy = position, z = radius
 uniform float iClumpFactor;
+uniform bool enableTransparency;
 out vec4 outColor;
 const float PI = 3.14159265359;
 
@@ -101,7 +102,7 @@ void main() {
     float alpha2 = m2 / total;
     cFinal = iColor * alpha1 + iCursorColor * alpha2;
   }
-  outColor = vec4(cFinal * f, 1.0);
+  outColor = vec4(cFinal * f, enableTransparency ? f : 1.0);
 }
 `;
 
@@ -115,6 +116,7 @@ const MetaBalls = ({
   clumpFactor = 1,
   cursorBallSize = 3,
   cursorBallColor = "#ffffff",
+  enableTransparency = false,
 }) => {
   const containerRef = useRef(null);
 
@@ -125,7 +127,7 @@ const MetaBalls = ({
     const dpr = 1;
     const renderer = new Renderer({ dpr, alpha: true, premultipliedAlpha: false });
     const gl = renderer.gl;
-    gl.clearColor(0, 0, 0, 0);
+    gl.clearColor(0, 0, 0, enableTransparency ? 0 : 1);
     container.appendChild(gl.canvas);
 
     const camera = new Camera(gl, {
@@ -156,6 +158,7 @@ const MetaBalls = ({
         iCursorBallSize: { value: cursorBallSize },
         iMetaBalls: { value: metaBallsUniform },
         iClumpFactor: { value: clumpFactor },
+        enableTransparency: { value: enableTransparency },
       },
     });
 
@@ -272,6 +275,7 @@ const MetaBalls = ({
     ballCount,
     clumpFactor,
     cursorBallSize,
+    enableTransparency,
   ]);
 
   return <div ref={containerRef} className="w-full h-full relative" />;

--- a/src/ts-default/Animations/MetaBalls/MetaBalls.tsx
+++ b/src/ts-default/Animations/MetaBalls/MetaBalls.tsx
@@ -20,6 +20,7 @@ type MetaBallsProps = {
   clumpFactor?: number;
   cursorBallSize?: number;
   cursorBallColor?: string;
+  enableTransparency?: boolean;
 };
 
 function parseHexColor(hex: string): [number, number, number] {
@@ -87,6 +88,7 @@ uniform int iBallCount;
 uniform float iCursorBallSize;
 uniform vec3 iMetaBalls[50]; // Precomputed: xy = position, z = radius
 uniform float iClumpFactor;
+uniform bool enableTransparency;
 out vec4 outColor;
 const float PI = 3.14159265359;
  
@@ -115,7 +117,7 @@ void main() {
         float alpha2 = m2 / total;
         cFinal = iColor * alpha1 + iCursorColor * alpha2;
     }
-    outColor = vec4(cFinal * f, 1.0);
+    outColor = vec4(cFinal * f, enableTransparency ? f : 1.0);
 }
 `;
 
@@ -137,6 +139,7 @@ const MetaBalls: React.FC<MetaBallsProps> = ({
   clumpFactor = 1,
   cursorBallSize = 3,
   cursorBallColor = "#ffffff",
+  enableTransparency = false,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -151,7 +154,7 @@ const MetaBalls: React.FC<MetaBallsProps> = ({
       premultipliedAlpha: false,
     });
     const gl = renderer.gl;
-    gl.clearColor(0, 0, 0, 0);
+    gl.clearColor(0, 0, 0, enableTransparency ? 0 : 1);
     container.appendChild(gl.canvas);
 
     const camera = new Camera(gl, {
@@ -187,6 +190,7 @@ const MetaBalls: React.FC<MetaBallsProps> = ({
         iCursorBallSize: { value: cursorBallSize },
         iMetaBalls: { value: metaBallsUniform },
         iClumpFactor: { value: clumpFactor },
+        enableTransparency: { value: enableTransparency },
       },
     });
 
@@ -307,6 +311,7 @@ const MetaBalls: React.FC<MetaBallsProps> = ({
     ballCount,
     clumpFactor,
     cursorBallSize,
+    enableTransparency,
   ]);
 
   return <div ref={containerRef} className="metaballs-container" />;

--- a/src/ts-tailwind/Animations/MetaBalls/MetaBalls.tsx
+++ b/src/ts-tailwind/Animations/MetaBalls/MetaBalls.tsx
@@ -19,6 +19,7 @@ type MetaBallsProps = {
   clumpFactor?: number;
   cursorBallSize?: number;
   cursorBallColor?: string;
+  enableTransparency?: boolean;
 };
 
 function parseHexColor(hex: string): [number, number, number] {
@@ -86,6 +87,7 @@ uniform int iBallCount;
 uniform float iCursorBallSize;
 uniform vec3 iMetaBalls[50]; // Precomputed: xy = position, z = radius
 uniform float iClumpFactor;
+uniform bool enableTransparency;
 out vec4 outColor;
 const float PI = 3.14159265359;
  
@@ -114,7 +116,7 @@ void main() {
         float alpha2 = m2 / total;
         cFinal = iColor * alpha1 + iCursorColor * alpha2;
     }
-    outColor = vec4(cFinal * f, 1.0);
+    outColor = vec4(cFinal * f, enableTransparency ? f : 1.0);
 }
 `;
 
@@ -136,6 +138,7 @@ const MetaBalls: React.FC<MetaBallsProps> = ({
   clumpFactor = 1,
   cursorBallSize = 3,
   cursorBallColor = "#ffffff",
+  enableTransparency = false,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -150,7 +153,7 @@ const MetaBalls: React.FC<MetaBallsProps> = ({
       premultipliedAlpha: false,
     });
     const gl = renderer.gl;
-    gl.clearColor(0, 0, 0, 0);
+    gl.clearColor(0, 0, 0, enableTransparency ? 0 : 1);
     container.appendChild(gl.canvas);
 
     const camera = new Camera(gl, {
@@ -186,6 +189,7 @@ const MetaBalls: React.FC<MetaBallsProps> = ({
         iCursorBallSize: { value: cursorBallSize },
         iMetaBalls: { value: metaBallsUniform },
         iClumpFactor: { value: clumpFactor },
+        enableTransparency: { value: enableTransparency },
       },
     });
 
@@ -306,6 +310,7 @@ const MetaBalls: React.FC<MetaBallsProps> = ({
     ballCount,
     clumpFactor,
     cursorBallSize,
+    enableTransparency,
   ]);
 
   return <div ref={containerRef} className="w-full h-full relative" />;


### PR DESCRIPTION
## Description
Added transparency support to MetaBalls components across all implementations. Components now accept an `enableTransparency` prop that toggles between the default black background and a transparent background, allowing them to blend with underlying content.

### Changes Made
- Added `enableTransparency` prop (default: false) to maintain backward compatibility
- Updated shader code to support dynamic transparency based on metaball field strength
- Modified renderer configuration to properly handle transparent backgrounds
- Implemented consistent behavior across all component versions:
  - ts-default/Animations/MetaBalls
  - ts-tailwind/Animations/MetaBalls
  - content/Animations/MetaBalls
  - tailwind/Animations/MetaBalls

#Video
https://drive.google.com/drive/folders/1lQi7VFyj8nkz3_vO7tNaVKbyio6-_uef?usp=sharing (Double click on video to preview)

### Usage
```jsx
// Default behavior (black background)
<MetaBalls />

// With transparency enabled
<MetaBalls enableTransparency={true} />



