### PR TITLE
[FEAT]: Fixed some minor style issues 

### DIFF
--- a/src/components/navs/Sidebar.jsx
+++ b/src/components/navs/Sidebar.jsx
@@ -110,7 +110,7 @@ const Sidebar = () => {
         </DrawerContent>
       </Drawer>
 
-      <Box as="nav" position="fixed" top="57px" height="calc(100vh - 57px)" className="sidebar" overflowY="auto" bg={sidebarBgColor} w={{ base: 0, md: 60 }} p={5} display={{ base: 'none', md: 'block' }}>
+      <Box as="nav" position="fixed" top="57px" height="calc(100vh - 57px)" className="sidebar" overflowY="auto" bg={sidebarBgColor} w={{ base: 0, md: 40 }} p={5} display={{ base: 'none', md: 'block' }}>
         <VStack align="stretch" spacing={4}>
           {CATEGORIES.map(category => (
             <Category

--- a/src/css/landing.css
+++ b/src/css/landing.css
@@ -312,7 +312,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  height: 100dvh;
+  min-height: 100dvh;
 }
 
 @media (max-height: 850px) {
@@ -334,7 +334,6 @@
 }
 
 @keyframes shake {
-
   0%,
   100% {
     transform: rotate(-5deg);
@@ -424,7 +423,7 @@
   width: 1px;
   height: 50px;
   margin: 20px auto;
-  position: absolute;
+  position: fixed;
   bottom: 0;
   z-index: 3;
   overflow: hidden;
@@ -535,3 +534,4 @@
   width: 100%;
   max-width: 600px;
 }
+


### PR DESCRIPTION
While browsing the page, in the Docs section, I noticed a possible bug with the scroll bar. When playing with different viewport sizes, I found another issue on the landing page: the hero-content and stats-content sections were overlapping.
Before the changes:
![Captura desde 2025-03-03 14-04-30](https://github.com/user-attachments/assets/250e5beb-8134-4de2-b38d-b84d3851d6e6)
![Captura desde 2025-03-03 14-12-39](https://github.com/user-attachments/assets/fc935064-a453-44a7-bd9c-2e486be3aa61)

After the changes:
![Captura desde 2025-03-03 14-15-48](https://github.com/user-attachments/assets/1343c161-2bd1-406f-bed3-ed75caf90fc8)
![Captura desde 2025-03-03 14-18-23](https://github.com/user-attachments/assets/0285e840-6f6c-40a4-a94f-4c72a7b25ca7)
