### PR TITLE
fix-types-on-RotatingText-ts

### DIFF
--- a/src/ts-default/TextAnimations/RotatingText/RotatingText.tsx
+++ b/src/ts-default/TextAnimations/RotatingText/RotatingText.tsx
@@ -8,7 +8,15 @@ import React, {
   useMemo,
   useState,
 } from "react";
-import { motion, AnimatePresence, Transition } from "framer-motion";
+import {
+  motion,
+  AnimatePresence,
+  Transition,
+  type VariantLabels,
+  type Target,
+  type AnimationControls,
+  type TargetAndTransition,
+} from "framer-motion";
 
 import "./RotatingText.css";
 
@@ -30,9 +38,9 @@ export interface RotatingTextProps
   > {
   texts: string[];
   transition?: Transition;
-  initial?: any;
-  animate?: any;
-  exit?: any;
+  initial?: boolean | Target | VariantLabels;
+  animate?: boolean | VariantLabels | AnimationControls | TargetAndTransition;
+  exit?: Target | VariantLabels;
   animatePresenceMode?: "sync" | "wait";
   animatePresenceInitial?: boolean;
   rotationInterval?: number;

--- a/src/ts-tailwind/TextAnimations/RotatingText/RotatingText.tsx
+++ b/src/ts-tailwind/TextAnimations/RotatingText/RotatingText.tsx
@@ -6,7 +6,15 @@ import React, {
   useMemo,
   useState,
 } from "react";
-import { motion, AnimatePresence, Transition } from "framer-motion";
+import {
+  motion,
+  AnimatePresence,
+  Transition,
+  type VariantLabels,
+  type Target,
+  type AnimationControls,
+  type TargetAndTransition,
+} from "framer-motion";
 
 function cn(...classes: (string | undefined | null | boolean)[]): string {
   return classes.filter(Boolean).join(" ");
@@ -26,9 +34,9 @@ export interface RotatingTextProps
   > {
   texts: string[];
   transition?: Transition;
-  initial?: any;
-  animate?: any;
-  exit?: any;
+  initial?: boolean | Target | VariantLabels;
+  animate?: boolean | VariantLabels | AnimationControls | TargetAndTransition;
+  exit?: Target | VariantLabels;
   animatePresenceMode?: "sync" | "wait";
   animatePresenceInitial?: boolean;
   rotationInterval?: number;


### PR DESCRIPTION
When I used the component RotatingText (TypeScript version) and deployed my project on Vercel, I was blocked in build due this error:

<img width="1202" alt="Screenshot 2025-03-06 at 10 32 26 PM" src="https://github.com/user-attachments/assets/1f66ca85-cbae-448f-90ee-ec128a5feb17" />

So I fixed and deploy went well (I just add the types from the lib, the same that the filed accept, so now the component prop reflects the lib types)

It is not a big deal, but can save 15 min of the next developer using this same component on Vercel

Note: It is only type related, so the Demo and tests will not got any changes, only linters 🙃
