### PR TITLE
Feat/blurtext typing error fix

### DIFF
--- a/src/ts-default/TextAnimations/BlurText/BlurText.tsx
+++ b/src/ts-default/TextAnimations/BlurText/BlurText.tsx
@@ -1,6 +1,8 @@
 import { useSprings, animated, SpringValue } from '@react-spring/web';
 import { useRef, useEffect, useState } from 'react';
 
+const AnimatedSpan = animated.span as React.FC<React.HTMLAttributes<HTMLSpanElement>>;
+
 type BlurTextProps = {
   text?: string;
   delay?: number;
@@ -90,7 +92,7 @@ const BlurText: React.FC<BlurTextProps> = ({
       style={{ display: 'flex', flexWrap: 'wrap' }}
     >
       {springs.map((props, index) => (
-        <animated.span
+        <AnimatedSpan
           key={index}
           style={{
             ...props,
@@ -100,7 +102,7 @@ const BlurText: React.FC<BlurTextProps> = ({
         >
           {elements[index] === ' ' ? '\u00A0' : elements[index]}
           {animateBy === 'words' && index < elements.length - 1 && '\u00A0'}
-        </animated.span>
+        </AnimatedSpan>
       ))}
     </p>
   );

--- a/src/ts-tailwind/TextAnimations/BlurText/BlurText.tsx
+++ b/src/ts-tailwind/TextAnimations/BlurText/BlurText.tsx
@@ -1,6 +1,8 @@
 import { useRef, useEffect, useState } from 'react';
 import { useSprings, animated, SpringValue } from '@react-spring/web';
 
+const AnimatedSpan = animated.span as React.FC<React.HTMLAttributes<HTMLSpanElement>>;
+
 interface BlurTextProps {
   text?: string;
   delay?: number;
@@ -90,14 +92,14 @@ const BlurText: React.FC<BlurTextProps> = ({
   return (
     <p ref={ref} className={`blur-text ${className} flex flex-wrap`}>
       {springs.map((props, index) => (
-        <animated.span
+        <AnimatedSpan
           key={index}
           style={props}
           className="inline-block transition-transform will-change-[transform,filter,opacity]"
         >
           {elements[index] === ' ' ? '\u00A0' : elements[index]}
           {animateBy === 'words' && index < elements.length - 1 && '\u00A0'}
-        </animated.span>
+        </AnimatedSpan>
       ))}
     </p>
   );


### PR DESCRIPTION
Previously typescript versions of the blurtext typography animation had an error preventing it from being built successfully due to some funny typescript buisness associated with the animated.span, this is fixed by explicitly declaring a new AnimatedSpan which prevents the TS error

Previous error now mitigated:
"Type '{ children: Element; key: number; style: { [x: string]: any; }; }' is not assignable to type 'IntrinsicAttributes & AnimatedProps<{ style?: { accentColor?: AccentColor | undefined; alignContent?: AlignContent | undefined; alignItems?: AlignItems | undefined; ... 841 more ...; matrix3d?: readonly [...] | undefined; } | undefined; }> & { ...; }'.\n  Property 'children' does not exist on type 'IntrinsicAttributes & AnimatedProps<{ style?: { accentColor?: AccentColor | undefined; alignContent?: AlignContent | undefined; alignItems?: AlignItems | undefined; ... 841 more ...; matrix3d?: readonly [...] | undefined; } | undefined; }> & { ...; }'."