### PR TITLE
Variable proximity calculate on mouse move

### DIFF
--- a/src/content/TextAnimations/VariableProximity/VariableProximity.jsx
+++ b/src/content/TextAnimations/VariableProximity/VariableProximity.jsx
@@ -61,6 +61,7 @@ const VariableProximity = forwardRef((props, ref) => {
   const letterRefs = useRef([]);
   const interpolatedSettingsRef = useRef([]);
   const mousePositionRef = useMousePositionRef(containerRef);
+  const lastPositionRef = useRef({ x: null, y: null });
 
   const parsedSettings = useMemo(() => {
     const parseSettings = (settingsStr) =>
@@ -99,6 +100,11 @@ const VariableProximity = forwardRef((props, ref) => {
   useAnimationFrame(() => {
     if (!containerRef?.current) return;
     const containerRect = containerRef.current.getBoundingClientRect();
+    const { x, y } = mousePositionRef.current;
+    if (lastPositionRef.current.x === x && lastPositionRef.current.y === y) {
+      return;
+    }
+    lastPositionRef.current = { x, y };
 
     letterRefs.current.forEach((letterRef, index) => {
       if (!letterRef) return;

--- a/src/tailwind/TextAnimations/VariableProximity/VariableProximity.jsx
+++ b/src/tailwind/TextAnimations/VariableProximity/VariableProximity.jsx
@@ -60,6 +60,7 @@ const VariableProximity = forwardRef((props, ref) => {
   const letterRefs = useRef([]);
   const interpolatedSettingsRef = useRef([]);
   const mousePositionRef = useMousePositionRef(containerRef);
+  const lastPositionRef = useRef({ x: null, y: null });
 
   const parsedSettings = useMemo(() => {
     const parseSettings = (settingsStr) =>
@@ -97,6 +98,12 @@ const VariableProximity = forwardRef((props, ref) => {
 
   useAnimationFrame(() => {
     if (!containerRef?.current) return;
+    const { x, y } = mousePositionRef.current;
+    if (lastPositionRef.current.x === x && lastPositionRef.current.y === y) {
+      return;
+    }
+    lastPositionRef.current = { x, y };
+
     const containerRect = containerRef.current.getBoundingClientRect();
 
     letterRefs.current.forEach((letterRef, index) => {

--- a/src/ts-default/TextAnimations/VariableProximity/VariableProximity.tsx
+++ b/src/ts-default/TextAnimations/VariableProximity/VariableProximity.tsx
@@ -76,6 +76,7 @@ const VariableProximity = forwardRef<HTMLSpanElement, VariableProximityProps>((p
     const letterRefs = useRef<(HTMLSpanElement | null)[]>([]);
     const interpolatedSettingsRef = useRef<string[]>([]);
     const mousePositionRef = useMousePositionRef(containerRef);
+    const lastPositionRef = useRef<{ x: number | null; y: number | null }>({ x: null, y: null });
 
     const parsedSettings = useMemo(() => {
         const parseSettings = (settingsStr: string) =>
@@ -113,6 +114,11 @@ const VariableProximity = forwardRef<HTMLSpanElement, VariableProximityProps>((p
 
     useAnimationFrame(() => {
         if (!containerRef?.current) return;
+        const { x, y } = mousePositionRef.current;
+        if (lastPositionRef.current.x === x && lastPositionRef.current.y === y) {
+          return;
+        }
+        lastPositionRef.current = { x, y };
         const containerRect = containerRef.current.getBoundingClientRect();
 
         letterRefs.current.forEach((letterRef, index) => {

--- a/src/ts-tailwind/TextAnimations/VariableProximity/VariableProximity.tsx
+++ b/src/ts-tailwind/TextAnimations/VariableProximity/VariableProximity.tsx
@@ -73,6 +73,7 @@ const VariableProximity = forwardRef<HTMLSpanElement, VariableProximityProps>((p
     const letterRefs = useRef<(HTMLSpanElement | null)[]>([]);
     const interpolatedSettingsRef = useRef<string[]>([]);
     const mousePositionRef = useMousePositionRef(containerRef);
+    const lastPositionRef = useRef<{ x: number | null; y: number | null }>({ x: null, y: null });
 
     const parsedSettings = useMemo(() => {
         const parseSettings = (settingsStr: string) =>
@@ -110,6 +111,11 @@ const VariableProximity = forwardRef<HTMLSpanElement, VariableProximityProps>((p
 
     useAnimationFrame(() => {
         if (!containerRef?.current) return;
+        const { x, y } = mousePositionRef.current;
+        if (lastPositionRef.current.x === x && lastPositionRef.current.y === y) {
+          return;
+        }
+        lastPositionRef.current = { x, y };
         const containerRect = containerRef.current.getBoundingClientRect();
 
         letterRefs.current.forEach((letterRef, index) => {


### PR DESCRIPTION
When I used the `VariableProximity` component, I noticed that my browser started to become slower, so I checked the code and realized that the distance calculation is running all the time and impacts the performance

https://github.com/user-attachments/assets/9a249766-8c8f-4b44-a680-f9b6ee10b3a2




So my fix is to do the same calculation, but only when the mouse moves


https://github.com/user-attachments/assets/aba013d6-2802-4d8b-955e-a955b97dca2a










