### PR TITLE
type-VariableProximity-rest

### DIFF
--- a/src/ts-default/TextAnimations/VariableProximity/VariableProximity.tsx
+++ b/src/ts-default/TextAnimations/VariableProximity/VariableProximity.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useMemo, useRef, useEffect, MutableRefObject, RefObject } from "react";
+import { forwardRef, useMemo, useRef, useEffect, MutableRefObject, RefObject, HTMLAttributes} from "react";
 import { motion } from "framer-motion";
 import "./VariableProximity.css";
 
@@ -46,7 +46,7 @@ function useMousePositionRef(containerRef: RefObject<HTMLElement>) {
     return positionRef;
 }
 
-interface VariableProximityProps {
+interface VariableProximityProps extends HTMLAttributes<HTMLSpanElement>{
     label: string;
     fromFontVariationSettings: string;
     toFontVariationSettings: string;
@@ -56,7 +56,6 @@ interface VariableProximityProps {
     className?: string;
     onClick?: () => void;
     style?: React.CSSProperties;
-    [key: string]: any;
 }
 
 const VariableProximity = forwardRef<HTMLSpanElement, VariableProximityProps>((props, ref) => {

--- a/src/ts-tailwind/TextAnimations/VariableProximity/VariableProximity.tsx
+++ b/src/ts-tailwind/TextAnimations/VariableProximity/VariableProximity.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useMemo, useRef, useEffect, MutableRefObject, CSSProperties } from "react";
+import { forwardRef, useMemo, useRef, useEffect, MutableRefObject, CSSProperties, HTMLAttributes } from "react";
 import { motion } from "framer-motion";
 
 function useAnimationFrame(callback: () => void) {
@@ -43,7 +43,7 @@ function useMousePositionRef(containerRef: MutableRefObject<HTMLElement | null>)
     return positionRef;
 }
 
-interface VariableProximityProps {
+interface VariableProximityProps extends HTMLAttributes<HTMLSpanElement>{
     label: string;
     fromFontVariationSettings: string;
     toFontVariationSettings: string;
@@ -53,7 +53,6 @@ interface VariableProximityProps {
     className?: string;
     onClick?: () => void;
     style?: CSSProperties;
-    [key: string]: any;
 }
 
 const VariableProximity = forwardRef<HTMLSpanElement, VariableProximityProps>((props, ref) => {


### PR DESCRIPTION
The `...restProps` is applied on a span HTML tag, and on `forwardRef` is already correctly typed. So I updated the component interface (`VariableProximityProps`) to match with that.

Before:
<img width="746" alt="Screenshot 2025-03-26 at 12 42 10 PM" src="https://github.com/user-attachments/assets/ce4f3b08-fa0d-4cee-89b5-c6979edf9df2" />

After:
<img width="727" alt="Screenshot 2025-03-26 at 12 42 26 PM" src="https://github.com/user-attachments/assets/16650004-10a5-43ff-8bd7-ecc88df066a5" />
