### PR TITLE
remove any from DecryptedText

### DIFF
--- a/src/ts-default/TextAnimations/DecryptedText/DecryptedText.tsx
+++ b/src/ts-default/TextAnimations/DecryptedText/DecryptedText.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useRef, ReactNode } from 'react'
-import { motion } from 'framer-motion'
+import { motion, HTMLMotionProps } from 'framer-motion'
 
 const styles = {
     wrapper: {
@@ -18,7 +18,7 @@ const styles = {
     },
 }
 
-interface DecryptedTextProps {
+interface DecryptedTextProps extends HTMLMotionProps<'span'> {
     text: string
     speed?: number
     maxIterations?: number
@@ -30,7 +30,6 @@ interface DecryptedTextProps {
     parentClassName?: string
     encryptedClassName?: string
     animateOn?: 'view' | 'hover'
-    children?: ReactNode
 }
 
 export default function DecryptedText({

--- a/src/ts-tailwind/TextAnimations/DecryptedText/DecryptedText.tsx
+++ b/src/ts-tailwind/TextAnimations/DecryptedText/DecryptedText.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useRef } from 'react'
-import { motion } from 'framer-motion'
+import { motion, HTMLMotionProps } from 'framer-motion'
 
-interface DecryptedTextProps {
+interface DecryptedTextProps extends HTMLMotionProps<'span'> {
     text: string
     speed?: number
     maxIterations?: number
@@ -13,7 +13,6 @@ interface DecryptedTextProps {
     encryptedClassName?: string
     parentClassName?: string
     animateOn?: 'view' | 'hover'
-    [key: string]: any
 }
 
 export default function DecryptedText({


### PR DESCRIPTION
Before
<img width="538" alt="Screenshot 2025-05-13 at 11 04 55 PM" src="https://github.com/user-attachments/assets/0a8b479d-d35b-4d0f-936c-0453b18a7d37" />

After
<img width="642" alt="Screenshot 2025-05-13 at 11 04 38 PM" src="https://github.com/user-attachments/assets/4b3658b5-3ea6-4ee8-9f9f-31223622b177" />

Note: for `src/ts-default/TextAnimations/DecryptedText/DecryptedText.tsx`, I follow the pattern of the tw component (I remove a child that it is part of the span props type, so it is all good