### PR TITLE
Fix: Add missing return statement in CircularGallery component

### DIFF
--- a/src/ts-tailwind/Components/CircularGallery/CircularGallery.tsx
+++ b/src/ts-tailwind/Components/CircularGallery/CircularGallery.tsx
@@ -710,7 +710,7 @@ export default function CircularGallery({
       app.destroy();
     };
   }, [items, bend, textColor, borderRadius, font]);
-  <div
+  return <div
     className="w-full h-full overflow-hidden cursor-grab active:cursor-grabbing"
     ref={containerRef}
   />;


### PR DESCRIPTION
This pull request addresses an issue where the CircularGallery component was not rendering correctly due to a missing return statement within the component's function or render method. This typically results in the component not displaying any UI or potentially causing errors.

**Related Issue:** Closes #213 