### PR TITLE
feat: Improve pointerup behaviour

### DIFF
--- a/src/content/Components/ElasticSlider/ElasticSlider.jsx
+++ b/src/content/Components/ElasticSlider/ElasticSlider.jsx
@@ -99,8 +99,15 @@ function Slider({
     e.currentTarget.setPointerCapture(e.pointerId);
   };
 
-  const handlePointerUp = () => {
+  const handlePointerUp = (e) => {
     animate(overflow, 0, { type: "spring", bounce: 0.5 });
+
+    const el = document.elementFromPoint(e.clientX, e.clientY);
+    if (el) {
+      el.addEventListener("click", (e_) => e_.stopPropagation(), {
+        once: true,
+      });
+    }
   };
 
   const getRangePercentage = () => {

--- a/src/content/Components/Lanyard/Lanyard.jsx
+++ b/src/content/Components/Lanyard/Lanyard.jsx
@@ -119,7 +119,17 @@ function Band({ maxSpeed = 50, minSpeed = 0 }) {
             position={[0, -1.2, -0.05]}
             onPointerOver={() => hover(true)}
             onPointerOut={() => hover(false)}
-            onPointerUp={(e) => (e.target.releasePointerCapture(e.pointerId), drag(false))}
+            onPointerUp={(e) => {
+              e.target.releasePointerCapture(e.pointerId);
+              drag(false);
+              
+              const el = document.elementFromPoint(e.clientX, e.clientY);
+              if (el) {
+                el.addEventListener("click", (e_) => e_.stopPropagation(), {
+                  once: true,
+                });
+              }
+            }}
             onPointerDown={(e) => (e.target.setPointerCapture(e.pointerId), drag(new THREE.Vector3().copy(e.point).sub(vec.copy(card.current.translation()))))}>
             <mesh geometry={nodes.card.geometry}>
               <meshPhysicalMaterial map={materials.base.map} map-anisotropy={16} clearcoat={1} clearcoatRoughness={0.15} roughness={0.9} metalness={0.8} />

--- a/src/tailwind/Components/ElasticSlider/ElasticSlider.jsx
+++ b/src/tailwind/Components/ElasticSlider/ElasticSlider.jsx
@@ -94,8 +94,15 @@ function Slider({
     e.currentTarget.setPointerCapture(e.pointerId);
   };
 
-  const handlePointerUp = () => {
+  const handlePointerUp = (e) => {
     animate(overflow, 0, { type: "spring", bounce: 0.5 });
+
+    const el = document.elementFromPoint(e.clientX, e.clientY);
+    if (el) {
+      el.addEventListener("click", (e_) => e_.stopPropagation(), {
+        once: true,
+      });
+    }
   };
 
   const getRangePercentage = () => {

--- a/src/tailwind/Components/Lanyard/Lanyard.jsx
+++ b/src/tailwind/Components/Lanyard/Lanyard.jsx
@@ -118,7 +118,17 @@ function Band({ maxSpeed = 50, minSpeed = 0 }) {
             position={[0, -1.2, -0.05]}
             onPointerOver={() => hover(true)}
             onPointerOut={() => hover(false)}
-            onPointerUp={(e) => (e.target.releasePointerCapture(e.pointerId), drag(false))}
+            onPointerUp={(e) => {
+              e.target.releasePointerCapture(e.pointerId);
+              drag(false);
+              
+              const el = document.elementFromPoint(e.clientX, e.clientY);
+              if (el) {
+                el.addEventListener("click", (e_) => e_.stopPropagation(), {
+                  once: true,
+                });
+              }
+            }}
             onPointerDown={(e) => (e.target.setPointerCapture(e.pointerId), drag(new THREE.Vector3().copy(e.point).sub(vec.copy(card.current.translation()))))}>
             <mesh geometry={nodes.card.geometry}>
               <meshPhysicalMaterial map={materials.base.map} map-anisotropy={16} clearcoat={1} clearcoatRoughness={0.15} roughness={0.9} metalness={0.8} />

--- a/src/ts-default/Components/ElasticSlider/ElasticSlider.tsx
+++ b/src/ts-default/Components/ElasticSlider/ElasticSlider.tsx
@@ -117,8 +117,15 @@ const Slider: React.FC<SliderProps> = ({
     e.currentTarget.setPointerCapture(e.pointerId);
   };
 
-  const handlePointerUp = () => {
+  const handlePointerUp = (e: React.PointerEvent<HTMLElement>) => {
     animate(overflow, 0, { type: "spring", bounce: 0.5 });
+
+    const el = document.elementFromPoint(e.clientX, e.clientY);
+    if (el) {
+      el.addEventListener("click", (e_) => e_.stopPropagation(), {
+        once: true,
+      });
+    }
   };
 
   const getRangePercentage = (): number => {

--- a/src/ts-default/Components/Lanyard/Lanyard.tsx
+++ b/src/ts-default/Components/Lanyard/Lanyard.tsx
@@ -254,6 +254,13 @@ function Band({ maxSpeed = 50, minSpeed = 0 }: BandProps) {
             onPointerUp={(e: any) => {
               e.target.releasePointerCapture(e.pointerId);
               drag(false);
+              
+              const el = document.elementFromPoint(e.clientX, e.clientY);
+              if (el) {
+                el.addEventListener("click", (e_: any) => e_.stopPropagation(), {
+                  once: true,
+                });
+              }
             }}
             onPointerDown={(e: any) => {
               e.target.setPointerCapture(e.pointerId);

--- a/src/ts-tailwind/Components/ElasticSlider/ElasticSlider.tsx
+++ b/src/ts-tailwind/Components/ElasticSlider/ElasticSlider.tsx
@@ -115,8 +115,15 @@ const Slider: React.FC<SliderProps> = ({
     e.currentTarget.setPointerCapture(e.pointerId);
   };
 
-  const handlePointerUp = () => {
+  const handlePointerUp = (e: React.PointerEvent<HTMLElement>) => {
     animate(overflow, 0, { type: "spring", bounce: 0.5 });
+
+    const el = document.elementFromPoint(e.clientX, e.clientY);
+    if (el) {
+      el.addEventListener("click", (e_) => e_.stopPropagation(), {
+        once: true,
+      });
+    }
   };
 
   const getRangePercentage = (): number => {

--- a/src/ts-tailwind/Components/Lanyard/Lanyard.tsx
+++ b/src/ts-tailwind/Components/Lanyard/Lanyard.tsx
@@ -252,6 +252,13 @@ function Band({ maxSpeed = 50, minSpeed = 0 }: BandProps) {
             onPointerUp={(e: any) => {
               e.target.releasePointerCapture(e.pointerId);
               drag(false);
+              
+              const el = document.elementFromPoint(e.clientX, e.clientY);
+              if (el) {
+                el.addEventListener("click", (e_: any) => e_.stopPropagation(), {
+                  once: true,
+                });
+              }
             }}
             onPointerDown={(e: any) => {
               e.target.setPointerCapture(e.pointerId);


### PR DESCRIPTION
Releasing the pointer while interacting with the `Elastic Slider` and `Lanyard` components would cause any elements below your pointer to be clicked. My PR temporarily prevents the element below the mouse from handling the click event (using the `once` attribute), thus introducing a more user-friendly behaviour.