### PR TITLE
fix: update useElementWidth to support strict types (fixes #230)

### DIFF
--- a/src/ts-default/TextAnimations/ScrollVelocity/ScrollVelocity.tsx
+++ b/src/ts-default/TextAnimations/ScrollVelocity/ScrollVelocity.tsx
@@ -45,7 +45,7 @@ interface ScrollVelocityProps {
   scrollerStyle?: React.CSSProperties;
 }
 
-function useElementWidth(ref: React.RefObject<HTMLElement>): number {
+function useElementWidth<T extends HTMLElement>(ref: React.RefObject<T | null>): number {
   const [width, setWidth] = useState(0);
 
   useLayoutEffect(() => {

--- a/src/ts-tailwind/TextAnimations/ScrollVelocity/ScrollVelocity.tsx
+++ b/src/ts-tailwind/TextAnimations/ScrollVelocity/ScrollVelocity.tsx
@@ -44,7 +44,7 @@ interface ScrollVelocityProps {
   scrollerStyle?: React.CSSProperties;
 }
 
-function useElementWidth(ref: React.RefObject<HTMLElement>): number {
+function useElementWidth<T extends HTMLElement>(ref: React.RefObject<T | null>): number {
   const [width, setWidth] = useState(0);
 
   useLayoutEffect(() => {


### PR DESCRIPTION
fixed issue #230 by updating the useElementWidth hook to use a generic type, resolving the ESLint strict type error.