### PR TITLE
Fixed, BUG: text-animations/circular-text - Tailwind versions are broken #264

### DIFF
--- a/src/tailwind/TextAnimations/CircularText/CircularText.jsx
+++ b/src/tailwind/TextAnimations/CircularText/CircularText.jsx
@@ -85,7 +85,7 @@ const CircularText = ({
 
   return (
     <motion.div
-      className={`circular-text ${className}`}
+      className={`m-0 mx-auto rounded-full w-[200px] h-[200px] relative font-bold text-white font-black text-center cursor-pointer origin-center ${className}`}
       style={{ rotate: rotation }}
       initial={{ rotate: 0 }}
       animate={controls}

--- a/src/tailwind/TextAnimations/CircularText/CircularText.jsx
+++ b/src/tailwind/TextAnimations/CircularText/CircularText.jsx
@@ -85,7 +85,7 @@ const CircularText = ({
 
   return (
     <motion.div
-      className={`m-0 mx-auto rounded-full w-[200px] h-[200px] relative font-bold text-white font-black text-center cursor-pointer origin-center ${className}`}
+      className={`m-0 mx-auto rounded-full w-[200px] h-[200px] relative text-white font-black text-center cursor-pointer origin-center ${className}`}
       style={{ rotate: rotation }}
       initial={{ rotate: 0 }}
       animate={controls}

--- a/src/ts-tailwind/TextAnimations/CircularText/CircularText.tsx
+++ b/src/ts-tailwind/TextAnimations/CircularText/CircularText.tsx
@@ -101,8 +101,8 @@ const CircularText: React.FC<CircularTextProps> = ({
 
   return (
     <motion.div
-      className={`circular-text ${className}`}
-      style={{ rotate: rotation }}
+    className={`m-0 mx-auto rounded-full w-[200px] h-[200px] relative font-black text-white text-center cursor-pointer origin-center ${className}`}
+    style={{ rotate: rotation }}
       initial={{ rotate: 0 }}
       animate={controls}
       onMouseEnter={handleHoverStart}


### PR DESCRIPTION
![Screenshot 2025-07-03 151235](https://github.com/user-attachments/assets/4854f9c9-1187-476a-b68a-6bb002f59ed5)

destination: src /tailwind/textAnimations/CircularText

-used tailwindcss to update the Circular Text component
-used the styles from the normal CSS component

PFA, screenshot from the local build.