### PR TITLE
Fix: Move click handler to <a> tag in GooeyNav to resolve event propa…

### DIFF
--- a/src/content/Components/GooeyNav/GooeyNav.jsx
+++ b/src/content/Components/GooeyNav/GooeyNav.jsx
@@ -19,22 +19,13 @@ const GooeyNav = ({
 
   const noise = (n = 1) => n / 2 - Math.random() * n;
 
-  const getXY = (
-    distance,
-    pointIndex,
-    totalPoints
-  ) => {
+  const getXY = (distance, pointIndex, totalPoints) => {
     const angle =
       ((360 + noise(8)) / totalPoints) * pointIndex * (Math.PI / 180);
     return [distance * Math.cos(angle), distance * Math.sin(angle)];
   };
 
-  const createParticle = (
-    i,
-    t,
-    d,
-    r
-  ) => {
+  const createParticle = (i, t, d, r) => {
     let rotate = noise(r / 10);
     return {
       start: getXY(d[0], particleCount - i, particleCount),
@@ -132,28 +123,22 @@ const GooeyNav = ({
       e.preventDefault();
       const liEl = e.currentTarget.parentElement;
       if (liEl) {
-        handleClick(
-          { currentTarget: liEl },
-          index
-        );
+        handleClick({ currentTarget: liEl }, index);
       }
     }
   };
 
   useEffect(() => {
     if (!navRef.current || !containerRef.current) return;
-    const activeLi = navRef.current.querySelectorAll("li")[
-      activeIndex
-    ];
+    const activeLi = navRef.current.querySelectorAll("li")[activeIndex];
     if (activeLi) {
       updateEffectPosition(activeLi);
       textRef.current?.classList.add("active");
     }
 
     const resizeObserver = new ResizeObserver(() => {
-      const currentActiveLi = navRef.current?.querySelectorAll("li")[
-        activeIndex
-      ];
+      const currentActiveLi =
+        navRef.current?.querySelectorAll("li")[activeIndex];
       if (currentActiveLi) {
         updateEffectPosition(currentActiveLi);
       }
@@ -170,10 +155,16 @@ const GooeyNav = ({
           {items.map((item, index) => (
             <li
               key={index}
-              className={activeIndex === index ? "active" : ""}
-              onClick={(e) => handleClick(e, index)}
+              className={`py-[0.6em] px-[1em] rounded-full relative transition-[background-color_color_box-shadow] duration-300 ease shadow-[0_0_0.5px_1.5px_transparent] text-white font-bold ${
+                activeIndex === index ? "active" : ""
+              }`}
             >
-              <a href={item.href} onKeyDown={(e) => handleKeyDown(e, index)}>
+              <a
+                href={item.href}
+                onClick={(e) => handleClick(e, index)}
+                onKeyDown={(e) => handleKeyDown(e, index)}
+                className="outline-none w-full h-full block cursor-pointer"
+              >
                 {item.label}
               </a>
             </li>


### PR DESCRIPTION
### Fixes: [#256](https://github.com/DavidHDev/react-bits/issues/256)

**Summary:**
This PR moves the `onClick` handler from `<li>` to `<a>` to resolve event propagation issues. It also ensures the `<a>` covers the full area with `w-full h-full block`.

Tested locally and verified the fix.
