### PR TITLE
[FIX}: Gooey Nav - Inconsistent Click and Navigation Behavior in <li> with Click Handlers and Styling

### DIFF
--- a/src/content/Components/GooeyNav/GooeyNav.css
+++ b/src/content/Components/GooeyNav/GooeyNav.css
@@ -33,6 +33,11 @@
   color: white;
 }
 
+.gooey-nav-container nav ul li a {
+  display: inline-block;
+  padding: 0.6em 1em;
+}
+
 .gooey-nav-container nav ul li:focus-within:has(:focus-visible) {
   box-shadow: 0 0 0.5px 1.5px white;
 }

--- a/src/content/Components/GooeyNav/GooeyNav.css
+++ b/src/content/Components/GooeyNav/GooeyNav.css
@@ -25,7 +25,6 @@
 }
 
 .gooey-nav-container nav ul li {
-  padding: 0.6em 1em;
   border-radius: 100vw;
   position: relative;
   cursor: pointer;

--- a/src/content/Components/GooeyNav/GooeyNav.jsx
+++ b/src/content/Components/GooeyNav/GooeyNav.jsx
@@ -1,5 +1,4 @@
 import { useRef, useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
 import "./GooeyNav.css";
 
 const GooeyNav = ({

--- a/src/content/Components/GooeyNav/GooeyNav.jsx
+++ b/src/content/Components/GooeyNav/GooeyNav.jsx
@@ -2,187 +2,181 @@ import { useRef, useEffect, useState } from "react";
 import "./GooeyNav.css";
 
 const GooeyNav = ({
-  items,
-  animationTime = 600,
-  particleCount = 15,
-  particleDistances = [90, 10],
-  particleR = 100,
-  timeVariance = 300,
-  colors = [1, 2, 3, 1, 2, 3, 1, 4],
-  initialActiveIndex = 0,
+    items,
+    animationTime = 600,
+    particleCount = 15,
+    particleDistances = [90, 10],
+    particleR = 100,
+    timeVariance = 300,
+    colors = [1, 2, 3, 1, 2, 3, 1, 4],
+    initialActiveIndex = 0,
 }) => {
-  const containerRef = useRef(null);
-  const navRef = useRef(null);
-  const filterRef = useRef(null);
-  const textRef = useRef(null);
-  const [activeIndex, setActiveIndex] = useState(initialActiveIndex);
+    const containerRef = useRef(null);
+    const navRef = useRef(null);
+    const filterRef = useRef(null);
+    const textRef = useRef(null);
+    const [activeIndex, setActiveIndex] = useState(initialActiveIndex);
 
-  const noise = (n = 1) => n / 2 - Math.random() * n;
+    const noise = (n = 1) => n / 2 - Math.random() * n;
 
-  const getXY = (
-    distance,
-    pointIndex,
-    totalPoints
-  ) => {
-    const angle =
-      ((360 + noise(8)) / totalPoints) * pointIndex * (Math.PI / 180);
-    return [distance * Math.cos(angle), distance * Math.sin(angle)];
-  };
-
-  const createParticle = (
-    i,
-    t,
-    d,
-    r
-  ) => {
-    let rotate = noise(r / 10);
-    return {
-      start: getXY(d[0], particleCount - i, particleCount),
-      end: getXY(d[1] + noise(7), particleCount - i, particleCount),
-      time: t,
-      scale: 1 + noise(0.2),
-      color: colors[Math.floor(Math.random() * colors.length)],
-      rotate: rotate > 0 ? (rotate + r / 20) * 10 : (rotate - r / 20) * 10,
+    const getXY = (distance, pointIndex, totalPoints) => {
+        const angle =
+            ((360 + noise(8)) / totalPoints) * pointIndex * (Math.PI / 180);
+        return [distance * Math.cos(angle), distance * Math.sin(angle)];
     };
-  };
 
-  const makeParticles = (element) => {
-    const d = particleDistances;
-    const r = particleR;
-    const bubbleTime = animationTime * 2 + timeVariance;
-    element.style.setProperty("--time", `${bubbleTime}ms`);
+    const createParticle = (i, t, d, r) => {
+        let rotate = noise(r / 10);
+        return {
+            start: getXY(d[0], particleCount - i, particleCount),
+            end: getXY(d[1] + noise(7), particleCount - i, particleCount),
+            time: t,
+            scale: 1 + noise(0.2),
+            color: colors[Math.floor(Math.random() * colors.length)],
+            rotate:
+                rotate > 0 ? (rotate + r / 20) * 10 : (rotate - r / 20) * 10,
+        };
+    };
 
-    for (let i = 0; i < particleCount; i++) {
-      const t = animationTime * 2 + noise(timeVariance * 2);
-      const p = createParticle(i, t, d, r);
-      element.classList.remove("active");
+    const makeParticles = (element) => {
+        const d = particleDistances;
+        const r = particleR;
+        const bubbleTime = animationTime * 2 + timeVariance;
+        element.style.setProperty("--time", `${bubbleTime}ms`);
 
-      setTimeout(() => {
-        const particle = document.createElement("span");
-        const point = document.createElement("span");
-        particle.classList.add("particle");
-        particle.style.setProperty("--start-x", `${p.start[0]}px`);
-        particle.style.setProperty("--start-y", `${p.start[1]}px`);
-        particle.style.setProperty("--end-x", `${p.end[0]}px`);
-        particle.style.setProperty("--end-y", `${p.end[1]}px`);
-        particle.style.setProperty("--time", `${p.time}ms`);
-        particle.style.setProperty("--scale", `${p.scale}`);
-        particle.style.setProperty("--color", `var(--color-${p.color}, white)`);
-        particle.style.setProperty("--rotate", `${p.rotate}deg`);
+        for (let i = 0; i < particleCount; i++) {
+            const t = animationTime * 2 + noise(timeVariance * 2);
+            const p = createParticle(i, t, d, r);
+            element.classList.remove("active");
 
-        point.classList.add("point");
-        particle.appendChild(point);
-        element.appendChild(particle);
-        requestAnimationFrame(() => {
-          element.classList.add("active");
+            setTimeout(() => {
+                const particle = document.createElement("span");
+                const point = document.createElement("span");
+                particle.classList.add("particle");
+                particle.style.setProperty("--start-x", `${p.start[0]}px`);
+                particle.style.setProperty("--start-y", `${p.start[1]}px`);
+                particle.style.setProperty("--end-x", `${p.end[0]}px`);
+                particle.style.setProperty("--end-y", `${p.end[1]}px`);
+                particle.style.setProperty("--time", `${p.time}ms`);
+                particle.style.setProperty("--scale", `${p.scale}`);
+                particle.style.setProperty(
+                    "--color",
+                    `var(--color-${p.color}, white)`
+                );
+                particle.style.setProperty("--rotate", `${p.rotate}deg`);
+
+                point.classList.add("point");
+                particle.appendChild(point);
+                element.appendChild(particle);
+                requestAnimationFrame(() => {
+                    element.classList.add("active");
+                });
+                setTimeout(() => {
+                    try {
+                        element.removeChild(particle);
+                    } catch {
+                        // Do nothing
+                    }
+                }, t);
+            }, 30);
+        }
+    };
+
+    const updateEffectPosition = (element) => {
+        if (!containerRef.current || !filterRef.current || !textRef.current)
+            return;
+        const containerRect = containerRef.current.getBoundingClientRect();
+        const pos = element.getBoundingClientRect();
+
+        const styles = {
+            left: `${pos.x - containerRect.x}px`,
+            top: `${pos.y - containerRect.y}px`,
+            width: `${pos.width}px`,
+            height: `${pos.height}px`,
+        };
+        Object.assign(filterRef.current.style, styles);
+        Object.assign(textRef.current.style, styles);
+        textRef.current.innerText = element.innerText;
+    };
+
+    const handleClick = (e, index) => {
+        const liEl = e.currentTarget;
+        if (activeIndex === index) return;
+
+        setActiveIndex(index);
+        updateEffectPosition(liEl);
+
+        if (filterRef.current) {
+            const particles = filterRef.current.querySelectorAll(".particle");
+            particles.forEach((p) => filterRef.current.removeChild(p));
+        }
+
+        if (textRef.current) {
+            textRef.current.classList.remove("active");
+
+            void textRef.current.offsetWidth;
+            textRef.current.classList.add("active");
+        }
+
+        if (filterRef.current) {
+            makeParticles(filterRef.current);
+        }
+    };
+
+    const handleKeyDown = (e, index) => {
+        if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            const liEl = e.currentTarget.parentElement;
+            if (liEl) {
+                handleClick({ currentTarget: liEl }, index);
+            }
+        }
+    };
+
+    useEffect(() => {
+        if (!navRef.current || !containerRef.current) return;
+        const activeLi = navRef.current.querySelectorAll("li")[activeIndex];
+        if (activeLi) {
+            updateEffectPosition(activeLi);
+            textRef.current?.classList.add("active");
+        }
+
+        const resizeObserver = new ResizeObserver(() => {
+            const currentActiveLi =
+                navRef.current?.querySelectorAll("li")[activeIndex];
+            if (currentActiveLi) {
+                updateEffectPosition(currentActiveLi);
+            }
         });
-        setTimeout(() => {
-          try {
-            element.removeChild(particle);
-          } catch {
-            // Do nothing
-          }
-        }, t);
-      }, 30);
-    }
-  };
 
-  const updateEffectPosition = (element) => {
-    if (!containerRef.current || !filterRef.current || !textRef.current) return;
-    const containerRect = containerRef.current.getBoundingClientRect();
-    const pos = element.getBoundingClientRect();
+        resizeObserver.observe(containerRef.current);
+        return () => resizeObserver.disconnect();
+    }, [activeIndex]);
 
-    const styles = {
-      left: `${pos.x - containerRect.x}px`,
-      top: `${pos.y - containerRect.y}px`,
-      width: `${pos.width}px`,
-      height: `${pos.height}px`,
-    };
-    Object.assign(filterRef.current.style, styles);
-    Object.assign(textRef.current.style, styles);
-    textRef.current.innerText = element.innerText;
-  };
-
-  const handleClick = (e, index) => {
-    const liEl = e.currentTarget;
-    if (activeIndex === index) return;
-
-    setActiveIndex(index);
-    updateEffectPosition(liEl);
-
-    if (filterRef.current) {
-      const particles = filterRef.current.querySelectorAll(".particle");
-      particles.forEach((p) => filterRef.current.removeChild(p));
-    }
-
-    if (textRef.current) {
-      textRef.current.classList.remove("active");
-
-      void textRef.current.offsetWidth;
-      textRef.current.classList.add("active");
-    }
-
-    if (filterRef.current) {
-      makeParticles(filterRef.current);
-    }
-  };
-
-  const handleKeyDown = (e, index) => {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      const liEl = e.currentTarget.parentElement;
-      if (liEl) {
-        handleClick(
-          { currentTarget: liEl },
-          index
-        );
-      }
-    }
-  };
-
-  useEffect(() => {
-    if (!navRef.current || !containerRef.current) return;
-    const activeLi = navRef.current.querySelectorAll("li")[
-      activeIndex
-    ];
-    if (activeLi) {
-      updateEffectPosition(activeLi);
-      textRef.current?.classList.add("active");
-    }
-
-    const resizeObserver = new ResizeObserver(() => {
-      const currentActiveLi = navRef.current?.querySelectorAll("li")[
-        activeIndex
-      ];
-      if (currentActiveLi) {
-        updateEffectPosition(currentActiveLi);
-      }
-    });
-
-    resizeObserver.observe(containerRef.current);
-    return () => resizeObserver.disconnect();
-  }, [activeIndex]);
-
-  return (
-    <div className="gooey-nav-container" ref={containerRef}>
-      <nav>
-        <ul ref={navRef}>
-          {items.map((item, index) => (
-            <li
-              key={index}
-              className={activeIndex === index ? "active" : ""}
-            >
-              <a href={item.href} onClick={(e) => handleClick(e, index)} onKeyDown={(e) => handleKeyDown(e, index)}>
-                {item.label}
-              </a>
-            </li>
-          ))}
-        </ul>
-      </nav>
-      <span className="effect filter" ref={filterRef} />
-      <span className="effect text" ref={textRef} />
-    </div>
-  );
+    return (
+        <div className="gooey-nav-container" ref={containerRef}>
+            <nav>
+                <ul ref={navRef}>
+                    {items.map((item, index) => (
+                        <li
+                            key={index}
+                            className={activeIndex === index ? "active" : ""}
+                        >
+                            <a
+                                href={item.href}
+                                onClick={(e) => handleClick(e, index)}
+                                onKeyDown={(e) => handleKeyDown(e, index)}
+                            >
+                                {item.label}
+                            </a>
+                        </li>
+                    ))}
+                </ul>
+            </nav>
+            <span className="effect filter" ref={filterRef} />
+            <span className="effect text" ref={textRef} />
+        </div>
+    );
 };
 
 export default GooeyNav;

--- a/src/content/Components/GooeyNav/GooeyNav.jsx
+++ b/src/content/Components/GooeyNav/GooeyNav.jsx
@@ -127,6 +127,8 @@ const GooeyNav = ({
     if (filterRef.current) {
       makeParticles(filterRef.current);
     }
+
+    navigate(items[index].href);
   };
 
   const handleKeyDown = (e, index) => {

--- a/src/content/Components/GooeyNav/GooeyNav.jsx
+++ b/src/content/Components/GooeyNav/GooeyNav.jsx
@@ -171,9 +171,8 @@ const GooeyNav = ({
             <li
               key={index}
               className={activeIndex === index ? "active" : ""}
-              onClick={(e) => handleClick(e, index)}
             >
-              <a href={item.href} onKeyDown={(e) => handleKeyDown(e, index)}>
+              <a href={item.href} onClick={(e) => handleClick(e, index)} onKeyDown={(e) => handleKeyDown(e, index)}>
                 {item.label}
               </a>
             </li>

--- a/src/content/Components/GooeyNav/GooeyNav.jsx
+++ b/src/content/Components/GooeyNav/GooeyNav.jsx
@@ -17,6 +17,7 @@ const GooeyNav = ({
   const filterRef = useRef(null);
   const textRef = useRef(null);
   const [activeIndex, setActiveIndex] = useState(initialActiveIndex);
+  const navigate = useNavigate();
 
   const noise = (n = 1) => n / 2 - Math.random() * n;
 

--- a/src/content/Components/GooeyNav/GooeyNav.jsx
+++ b/src/content/Components/GooeyNav/GooeyNav.jsx
@@ -16,7 +16,6 @@ const GooeyNav = ({
   const filterRef = useRef(null);
   const textRef = useRef(null);
   const [activeIndex, setActiveIndex] = useState(initialActiveIndex);
-  const navigate = useNavigate();
 
   const noise = (n = 1) => n / 2 - Math.random() * n;
 
@@ -126,8 +125,6 @@ const GooeyNav = ({
     if (filterRef.current) {
       makeParticles(filterRef.current);
     }
-
-    navigate(items[index].href);
   };
 
   const handleKeyDown = (e, index) => {

--- a/src/content/Components/GooeyNav/GooeyNav.jsx
+++ b/src/content/Components/GooeyNav/GooeyNav.jsx
@@ -153,7 +153,6 @@ const GooeyNav = ({
         return () => resizeObserver.disconnect();
     }, [activeIndex]);
 
-<<<<<<< HEAD
     return (
         <div className="gooey-nav-container" ref={containerRef}>
             <nav>
@@ -178,103 +177,6 @@ const GooeyNav = ({
             <span className="effect text" ref={textRef} />
         </div>
     );
-=======
-    const styles = {
-      left: `${pos.x - containerRect.x}px`,
-      top: `${pos.y - containerRect.y}px`,
-      width: `${pos.width}px`,
-      height: `${pos.height}px`,
-    };
-    Object.assign(filterRef.current.style, styles);
-    Object.assign(textRef.current.style, styles);
-    textRef.current.innerText = element.innerText;
-  };
-
-  const handleClick = (e, index) => {
-    const liEl = e.currentTarget;
-    if (activeIndex === index) return;
-
-    setActiveIndex(index);
-    updateEffectPosition(liEl);
-
-    if (filterRef.current) {
-      const particles = filterRef.current.querySelectorAll(".particle");
-      particles.forEach((p) => filterRef.current.removeChild(p));
-    }
-
-    if (textRef.current) {
-      textRef.current.classList.remove("active");
-
-      void textRef.current.offsetWidth;
-      textRef.current.classList.add("active");
-    }
-
-    if (filterRef.current) {
-      makeParticles(filterRef.current);
-    }
-  };
-
-  const handleKeyDown = (e, index) => {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      const liEl = e.currentTarget.parentElement;
-      if (liEl) {
-        handleClick(
-          { currentTarget: liEl },
-          index
-        );
-      }
-    }
-  };
-
-  useEffect(() => {
-    if (!navRef.current || !containerRef.current) return;
-    const activeLi = navRef.current.querySelectorAll("li")[
-      activeIndex
-    ];
-    if (activeLi) {
-      updateEffectPosition(activeLi);
-      textRef.current?.classList.add("active");
-    }
-
-    const resizeObserver = new ResizeObserver(() => {
-      const currentActiveLi = navRef.current?.querySelectorAll("li")[
-        activeIndex
-      ];
-      if (currentActiveLi) {
-        updateEffectPosition(currentActiveLi);
-      }
-    });
-
-    resizeObserver.observe(containerRef.current);
-    return () => resizeObserver.disconnect();
-  }, [activeIndex]);
-
-  return (
-    <div className="gooey-nav-container" ref={containerRef}>
-      <nav>
-        <ul ref={navRef}>
-          {items.map((item, index) => (
-            <li
-              key={index}
-              className={activeIndex === index ? "active" : ""}
-            >
-              <a
-                href={item.href}
-                onClick={(e) => handleClick(e, index)}
-                onKeyDown={(e) => handleKeyDown(e, index)}
-              >
-                {item.label}
-              </a>
-            </li>
-          ))}
-        </ul>
-      </nav>
-      <span className="effect filter" ref={filterRef} />
-      <span className="effect text" ref={textRef} />
-    </div>
-  );
->>>>>>> fdaaed0bd6092848d81e96e9d10bf4c970d9362b
 };
 
 export default GooeyNav;

--- a/src/content/Components/GooeyNav/GooeyNav.jsx
+++ b/src/content/Components/GooeyNav/GooeyNav.jsx
@@ -1,4 +1,5 @@
 import { useRef, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import "./GooeyNav.css";
 
 const GooeyNav = ({

--- a/src/tailwind/Components/GooeyNav/GooeyNav.jsx
+++ b/src/tailwind/Components/GooeyNav/GooeyNav.jsx
@@ -134,11 +134,11 @@ const GooeyNav = ({
         return () => resizeObserver.disconnect();
     }, [activeIndex]);
 
-  return (
-    <>
-      {/* This effect is quite difficult to recreate faithfully using Tailwind, so a style tag is a necessary workaround */}
-      <style>
-        {`
+    return (
+        <>
+            {/* This effect is quite difficult to recreate faithfully using Tailwind, so a style tag is a necessary workaround */}
+            <style>
+                {`
           :root {
             --linear-ease: linear(0, 0.068, 0.19 2.7%, 0.804 8.1%, 1.037, 1.199 13.2%, 1.245, 1.27 15.8%, 1.274, 1.272 17.4%, 1.249 19.1%, 0.996 28%, 0.949, 0.928 33.3%, 0.926, 0.933 36.8%, 1.001 45.6%, 1.013, 1.019 50.8%, 1.018 54.4%, 1 63.1%, 0.995 68%, 1.001 85%, 1);
           }
@@ -274,45 +274,44 @@ const GooeyNav = ({
             z-index: -1;
           }
         `}
-      </style>
-      <div className="relative" ref={containerRef}>
-        <nav
-          className="flex relative"
-          style={{ transform: "translate3d(0,0,0.01px)" }}
-        >
-          <ul
-            ref={navRef}
-            className="flex gap-8 list-none p-0 px-4 m-0 relative z-[3]"
-            style={{
-              color: "white",
-              textShadow: "0 1px 1px hsl(205deg 30% 10% / 0.2)",
-            }}
-          >
-            {items.map((item, index) => (
-              <li
-                key={index}
+            </style>
+            <div className="relative" ref={containerRef}>
+                <nav
+                    className="flex relative"
+                    style={{ transform: "translate3d(0,0,0.01px)" }}
+                >
+                    <ul
+                        ref={navRef}
+                        className="flex gap-8 list-none p-0 px-4 m-0 relative z-[3]"
+                        style={{
+                            color: "white",
+                            textShadow: "0 1px 1px hsl(205deg 30% 10% / 0.2)",
+                        }}
+                    >
+                        {items.map((item, index) => (
+                            <li
+                                key={index}
                                 className={`rounded-full relative cursor-pointer transition-[background-color_color_box-shadow] duration-300 ease shadow-[0_0_0.5px_1.5px_transparent] text-white ${
                                     activeIndex === index ? "active" : ""
                                 }`}
-                onClick={(e) => handleClick(e, index)}
-              >
-                <a
+                            >
+                                <a
                                     onClick={(e) => handleClick(e, index)}
-                  href={item.href}
-                  onKeyDown={(e) => handleKeyDown(e, index)}
+                                    href={item.href}
+                                    onKeyDown={(e) => handleKeyDown(e, index)}
                                     className="outline-none py-[0.6em] px-[1em] inline-block"
-                >
-                  {item.label}
-                </a>
-              </li>
-            ))}
-          </ul>
-        </nav>
-        <span className="effect filter" ref={filterRef} />
-        <span className="effect text" ref={textRef} />
-      </div>
-    </>
-  );
+                                >
+                                    {item.label}
+                                </a>
+                            </li>
+                        ))}
+                    </ul>
+                </nav>
+                <span className="effect filter" ref={filterRef} />
+                <span className="effect text" ref={textRef} />
+            </div>
+        </>
+    );
 };
 
 export default GooeyNav;

--- a/src/tailwind/Components/GooeyNav/GooeyNav.jsx
+++ b/src/tailwind/Components/GooeyNav/GooeyNav.jsx
@@ -274,39 +274,11 @@ const GooeyNav = ({
             z-index: -1;
           }
         `}
-<<<<<<< HEAD
             </style>
             <div className="relative" ref={containerRef}>
                 <nav
                     className="flex relative"
                     style={{ transform: "translate3d(0,0,0.01px)" }}
-=======
-      </style>
-      <div className="relative" ref={containerRef}>
-        <nav
-          className="flex relative"
-          style={{ transform: "translate3d(0,0,0.01px)" }}
-        >
-          <ul
-            ref={navRef}
-            className="flex gap-8 list-none p-0 px-4 m-0 relative z-[3]"
-            style={{
-              color: "white",
-              textShadow: "0 1px 1px hsl(205deg 30% 10% / 0.2)",
-            }}
-          >
-            {items.map((item, index) => (
-              <li
-                key={index}
-                className={`py-[0.6em] px-[1em] rounded-full relative cursor-pointer transition-[background-color_color_box-shadow] duration-300 ease shadow-[0_0_0.5px_1.5px_transparent] text-white ${activeIndex === index ? "active" : ""
-                  }`}
-              >
-                <a
-                  href={item.href}
-                  onClick={(e) => handleClick(e, index)}
-                  onKeyDown={(e) => handleKeyDown(e, index)}
-                  className="outline-none w-full h-full block cursor-pointer"
->>>>>>> fdaaed0bd6092848d81e96e9d10bf4c970d9362b
                 >
                     <ul
                         ref={navRef}

--- a/src/tailwind/Components/GooeyNav/GooeyNav.jsx
+++ b/src/tailwind/Components/GooeyNav/GooeyNav.jsx
@@ -1,4 +1,5 @@
 import { useRef, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 
 const GooeyNav = ({
   items,

--- a/src/tailwind/Components/GooeyNav/GooeyNav.jsx
+++ b/src/tailwind/Components/GooeyNav/GooeyNav.jsx
@@ -112,6 +112,8 @@ const GooeyNav = ({
     if (filterRef.current) {
       makeParticles(filterRef.current);
     }
+
+    navigate(items[index].href);
   };
   const handleKeyDown = (
     e,

--- a/src/tailwind/Components/GooeyNav/GooeyNav.jsx
+++ b/src/tailwind/Components/GooeyNav/GooeyNav.jsx
@@ -1,154 +1,138 @@
 import { useRef, useEffect, useState } from "react";
 
 const GooeyNav = ({
-  items,
-  animationTime = 600,
-  particleCount = 15,
-  particleDistances = [90, 10],
-  particleR = 100,
-  timeVariance = 300,
-  colors = [1, 2, 3, 1, 2, 3, 1, 4],
-  initialActiveIndex = 0,
+    items,
+    animationTime = 600,
+    particleCount = 15,
+    particleDistances = [90, 10],
+    particleR = 100,
+    timeVariance = 300,
+    colors = [1, 2, 3, 1, 2, 3, 1, 4],
+    initialActiveIndex = 0,
 }) => {
-  const containerRef = useRef(null);
-  const navRef = useRef(null);
-  const filterRef = useRef(null);
-  const textRef = useRef(null);
-  const [activeIndex, setActiveIndex] = useState(initialActiveIndex);
-  const navigate = useNavigate();
+    const containerRef = useRef(null);
+    const navRef = useRef(null);
+    const filterRef = useRef(null);
+    const textRef = useRef(null);
+    const [activeIndex, setActiveIndex] = useState(initialActiveIndex);
 
-  const noise = (n = 1) => n / 2 - Math.random() * n;
-  const getXY = (
-    distance,
-    pointIndex,
-    totalPoints
-  ) => {
-    const angle =
-      ((360 + noise(8)) / totalPoints) * pointIndex * (Math.PI / 180);
-    return [distance * Math.cos(angle), distance * Math.sin(angle)];
-  };
-  const createParticle = (
-    i,
-    t,
-    d,
-    r
-  ) => {
-    let rotate = noise(r / 10);
-    return {
-      start: getXY(d[0], particleCount - i, particleCount),
-      end: getXY(d[1] + noise(7), particleCount - i, particleCount),
-      time: t,
-      scale: 1 + noise(0.2),
-      color: colors[Math.floor(Math.random() * colors.length)],
-      rotate: rotate > 0 ? (rotate + r / 20) * 10 : (rotate - r / 20) * 10,
+    const noise = (n = 1) => n / 2 - Math.random() * n;
+    const getXY = (distance, pointIndex, totalPoints) => {
+        const angle =
+            ((360 + noise(8)) / totalPoints) * pointIndex * (Math.PI / 180);
+        return [distance * Math.cos(angle), distance * Math.sin(angle)];
     };
-  };
-  const makeParticles = (element) => {
-    const d = particleDistances;
-    const r = particleR;
-    const bubbleTime = animationTime * 2 + timeVariance;
-    element.style.setProperty("--time", `${bubbleTime}ms`);
-    for (let i = 0; i < particleCount; i++) {
-      const t = animationTime * 2 + noise(timeVariance * 2);
-      const p = createParticle(i, t, d, r);
-      element.classList.remove("active");
-      setTimeout(() => {
-        const particle = document.createElement("span");
-        const point = document.createElement("span");
-        particle.classList.add("particle");
-        particle.style.setProperty("--start-x", `${p.start[0]}px`);
-        particle.style.setProperty("--start-y", `${p.start[1]}px`);
-        particle.style.setProperty("--end-x", `${p.end[0]}px`);
-        particle.style.setProperty("--end-y", `${p.end[1]}px`);
-        particle.style.setProperty("--time", `${p.time}ms`);
-        particle.style.setProperty("--scale", `${p.scale}`);
-        particle.style.setProperty("--color", `var(--color-${p.color}, white)`);
-        particle.style.setProperty("--rotate", `${p.rotate}deg`);
-        point.classList.add("point");
-        particle.appendChild(point);
-        element.appendChild(particle);
-        requestAnimationFrame(() => {
-          element.classList.add("active");
+    const createParticle = (i, t, d, r) => {
+        let rotate = noise(r / 10);
+        return {
+            start: getXY(d[0], particleCount - i, particleCount),
+            end: getXY(d[1] + noise(7), particleCount - i, particleCount),
+            time: t,
+            scale: 1 + noise(0.2),
+            color: colors[Math.floor(Math.random() * colors.length)],
+            rotate:
+                rotate > 0 ? (rotate + r / 20) * 10 : (rotate - r / 20) * 10,
+        };
+    };
+    const makeParticles = (element) => {
+        const d = particleDistances;
+        const r = particleR;
+        const bubbleTime = animationTime * 2 + timeVariance;
+        element.style.setProperty("--time", `${bubbleTime}ms`);
+        for (let i = 0; i < particleCount; i++) {
+            const t = animationTime * 2 + noise(timeVariance * 2);
+            const p = createParticle(i, t, d, r);
+            element.classList.remove("active");
+            setTimeout(() => {
+                const particle = document.createElement("span");
+                const point = document.createElement("span");
+                particle.classList.add("particle");
+                particle.style.setProperty("--start-x", `${p.start[0]}px`);
+                particle.style.setProperty("--start-y", `${p.start[1]}px`);
+                particle.style.setProperty("--end-x", `${p.end[0]}px`);
+                particle.style.setProperty("--end-y", `${p.end[1]}px`);
+                particle.style.setProperty("--time", `${p.time}ms`);
+                particle.style.setProperty("--scale", `${p.scale}`);
+                particle.style.setProperty(
+                    "--color",
+                    `var(--color-${p.color}, white)`
+                );
+                particle.style.setProperty("--rotate", `${p.rotate}deg`);
+                point.classList.add("point");
+                particle.appendChild(point);
+                element.appendChild(particle);
+                requestAnimationFrame(() => {
+                    element.classList.add("active");
+                });
+                setTimeout(() => {
+                    try {
+                        element.removeChild(particle);
+                    } catch {
+                        // do nothing
+                    }
+                }, t);
+            }, 30);
+        }
+    };
+    const updateEffectPosition = (element) => {
+        if (!containerRef.current || !filterRef.current || !textRef.current)
+            return;
+        const containerRect = containerRef.current.getBoundingClientRect();
+        const pos = element.getBoundingClientRect();
+        const styles = {
+            left: `${pos.x - containerRect.x}px`,
+            top: `${pos.y - containerRect.y}px`,
+            width: `${pos.width}px`,
+            height: `${pos.height}px`,
+        };
+        Object.assign(filterRef.current.style, styles);
+        Object.assign(textRef.current.style, styles);
+        textRef.current.innerText = element.innerText;
+    };
+    const handleClick = (e, index) => {
+        const liEl = e.currentTarget;
+        if (activeIndex === index) return;
+        setActiveIndex(index);
+        updateEffectPosition(liEl);
+        if (filterRef.current) {
+            const particles = filterRef.current.querySelectorAll(".particle");
+            particles.forEach((p) => filterRef.current.removeChild(p));
+        }
+        if (textRef.current) {
+            textRef.current.classList.remove("active");
+            void textRef.current.offsetWidth;
+            textRef.current.classList.add("active");
+        }
+        if (filterRef.current) {
+            makeParticles(filterRef.current);
+        }
+    };
+    const handleKeyDown = (e, index) => {
+        if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            const liEl = e.currentTarget.parentElement;
+            if (liEl) {
+                handleClick({ currentTarget: liEl }, index);
+            }
+        }
+    };
+    useEffect(() => {
+        if (!navRef.current || !containerRef.current) return;
+        const activeLi = navRef.current.querySelectorAll("li")[activeIndex];
+        if (activeLi) {
+            updateEffectPosition(activeLi);
+            textRef.current?.classList.add("active");
+        }
+        const resizeObserver = new ResizeObserver(() => {
+            const currentActiveLi =
+                navRef.current?.querySelectorAll("li")[activeIndex];
+            if (currentActiveLi) {
+                updateEffectPosition(currentActiveLi);
+            }
         });
-        setTimeout(() => {
-          try {
-            element.removeChild(particle);
-          } catch {
-            // do nothing
-          }
-        }, t);
-      }, 30);
-    }
-  };
-  const updateEffectPosition = (element) => {
-    if (!containerRef.current || !filterRef.current || !textRef.current) return;
-    const containerRect = containerRef.current.getBoundingClientRect();
-    const pos = element.getBoundingClientRect();
-    const styles = {
-      left: `${pos.x - containerRect.x}px`,
-      top: `${pos.y - containerRect.y}px`,
-      width: `${pos.width}px`,
-      height: `${pos.height}px`,
-    };
-    Object.assign(filterRef.current.style, styles);
-    Object.assign(textRef.current.style, styles);
-    textRef.current.innerText = element.innerText;
-  };
-  const handleClick = (e, index) => {
-    const liEl = e.currentTarget;
-    if (activeIndex === index) return;
-    setActiveIndex(index);
-    updateEffectPosition(liEl);
-    if (filterRef.current) {
-      const particles = filterRef.current.querySelectorAll(".particle");
-      particles.forEach((p) => filterRef.current.removeChild(p));
-    }
-    if (textRef.current) {
-      textRef.current.classList.remove("active");
-      void textRef.current.offsetWidth;
-      textRef.current.classList.add("active");
-    }
-    if (filterRef.current) {
-      makeParticles(filterRef.current);
-    }
-
-    navigate(items[index].href);
-  };
-  const handleKeyDown = (
-    e,
-    index
-  ) => {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      const liEl = e.currentTarget.parentElement;
-      if (liEl) {
-        handleClick(
-          { currentTarget: liEl },
-          index
-        );
-      }
-    }
-  };
-  useEffect(() => {
-    if (!navRef.current || !containerRef.current) return;
-    const activeLi = navRef.current.querySelectorAll("li")[
-      activeIndex
-    ];
-    if (activeLi) {
-      updateEffectPosition(activeLi);
-      textRef.current?.classList.add("active");
-    }
-    const resizeObserver = new ResizeObserver(() => {
-      const currentActiveLi = navRef.current?.querySelectorAll("li")[
-        activeIndex
-      ];
-      if (currentActiveLi) {
-        updateEffectPosition(currentActiveLi);
-      }
-    });
-    resizeObserver.observe(containerRef.current);
-    return () => resizeObserver.disconnect();
-  }, [activeIndex]);
+        resizeObserver.observe(containerRef.current);
+        return () => resizeObserver.disconnect();
+    }, [activeIndex]);
 
   return (
     <>

--- a/src/tailwind/Components/GooeyNav/GooeyNav.jsx
+++ b/src/tailwind/Components/GooeyNav/GooeyNav.jsx
@@ -296,6 +296,7 @@ const GooeyNav = ({
                 onClick={(e) => handleClick(e, index)}
               >
                 <a
+                                    onClick={(e) => handleClick(e, index)}
                   href={item.href}
                   onKeyDown={(e) => handleKeyDown(e, index)}
                   className="outline-none"

--- a/src/tailwind/Components/GooeyNav/GooeyNav.jsx
+++ b/src/tailwind/Components/GooeyNav/GooeyNav.jsx
@@ -291,15 +291,16 @@ const GooeyNav = ({
             {items.map((item, index) => (
               <li
                 key={index}
-                className={`py-[0.6em] px-[1em] rounded-full relative cursor-pointer transition-[background-color_color_box-shadow] duration-300 ease shadow-[0_0_0.5px_1.5px_transparent] text-white ${activeIndex === index ? "active" : ""
-                  }`}
+                                className={`rounded-full relative cursor-pointer transition-[background-color_color_box-shadow] duration-300 ease shadow-[0_0_0.5px_1.5px_transparent] text-white ${
+                                    activeIndex === index ? "active" : ""
+                                }`}
                 onClick={(e) => handleClick(e, index)}
               >
                 <a
                                     onClick={(e) => handleClick(e, index)}
                   href={item.href}
                   onKeyDown={(e) => handleKeyDown(e, index)}
-                  className="outline-none"
+                                    className="outline-none py-[0.6em] px-[1em] inline-block"
                 >
                   {item.label}
                 </a>

--- a/src/tailwind/Components/GooeyNav/GooeyNav.jsx
+++ b/src/tailwind/Components/GooeyNav/GooeyNav.jsx
@@ -16,6 +16,8 @@ const GooeyNav = ({
   const filterRef = useRef(null);
   const textRef = useRef(null);
   const [activeIndex, setActiveIndex] = useState(initialActiveIndex);
+  const navigate = useNavigate();
+
   const noise = (n = 1) => n / 2 - Math.random() * n;
   const getXY = (
     distance,

--- a/src/tailwind/Components/GooeyNav/GooeyNav.jsx
+++ b/src/tailwind/Components/GooeyNav/GooeyNav.jsx
@@ -1,5 +1,4 @@
 import { useRef, useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
 
 const GooeyNav = ({
   items,

--- a/src/ts-default/Components/GooeyNav/GooeyNav.css
+++ b/src/ts-default/Components/GooeyNav/GooeyNav.css
@@ -33,6 +33,11 @@
   color: white;
 }
 
+.gooey-nav-container nav ul li a {
+  display: inline-block;
+  padding: 0.6em 1em;
+}
+
 .gooey-nav-container nav ul li:focus-within:has(:focus-visible) {
   box-shadow: 0 0 0.5px 1.5px white;
 }

--- a/src/ts-default/Components/GooeyNav/GooeyNav.css
+++ b/src/ts-default/Components/GooeyNav/GooeyNav.css
@@ -25,7 +25,6 @@
 }
 
 .gooey-nav-container nav ul li {
-  padding: 0.6em 1em;
   border-radius: 100vw;
   position: relative;
   cursor: pointer;

--- a/src/ts-default/Components/GooeyNav/GooeyNav.tsx
+++ b/src/ts-default/Components/GooeyNav/GooeyNav.tsx
@@ -2,206 +2,220 @@ import React, { useRef, useEffect, useState } from "react";
 import "./GooeyNav.css";
 
 interface GooeyNavItem {
-  label: string;
-  href: string;
+    label: string;
+    href: string;
 }
 
 export interface GooeyNavProps {
-  items: GooeyNavItem[];
-  animationTime?: number;
-  particleCount?: number;
-  particleDistances?: [number, number];
-  particleR?: number;
-  timeVariance?: number;
-  colors?: number[];
-  initialActiveIndex?: number;
+    items: GooeyNavItem[];
+    animationTime?: number;
+    particleCount?: number;
+    particleDistances?: [number, number];
+    particleR?: number;
+    timeVariance?: number;
+    colors?: number[];
+    initialActiveIndex?: number;
 }
 
 const GooeyNav: React.FC<GooeyNavProps> = ({
-  items,
-  animationTime = 600,
-  particleCount = 15,
-  particleDistances = [90, 10],
-  particleR = 100,
-  timeVariance = 300,
-  colors = [1, 2, 3, 1, 2, 3, 1, 4],
-  initialActiveIndex = 0,
+    items,
+    animationTime = 600,
+    particleCount = 15,
+    particleDistances = [90, 10],
+    particleR = 100,
+    timeVariance = 300,
+    colors = [1, 2, 3, 1, 2, 3, 1, 4],
+    initialActiveIndex = 0,
 }) => {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const navRef = useRef<HTMLUListElement>(null);
-  const filterRef = useRef<HTMLSpanElement>(null);
-  const textRef = useRef<HTMLSpanElement>(null);
-  const [activeIndex, setActiveIndex] = useState<number>(initialActiveIndex);
+    const containerRef = useRef<HTMLDivElement>(null);
+    const navRef = useRef<HTMLUListElement>(null);
+    const filterRef = useRef<HTMLSpanElement>(null);
+    const textRef = useRef<HTMLSpanElement>(null);
+    const [activeIndex, setActiveIndex] = useState<number>(initialActiveIndex);
 
-  const noise = (n = 1) => n / 2 - Math.random() * n;
+    const noise = (n = 1) => n / 2 - Math.random() * n;
 
-  const getXY = (
-    distance: number,
-    pointIndex: number,
-    totalPoints: number
-  ): [number, number] => {
-    const angle =
-      ((360 + noise(8)) / totalPoints) * pointIndex * (Math.PI / 180);
-    return [distance * Math.cos(angle), distance * Math.sin(angle)];
-  };
-
-  const createParticle = (
-    i: number,
-    t: number,
-    d: [number, number],
-    r: number
-  ) => {
-    let rotate = noise(r / 10);
-    return {
-      start: getXY(d[0], particleCount - i, particleCount),
-      end: getXY(d[1] + noise(7), particleCount - i, particleCount),
-      time: t,
-      scale: 1 + noise(0.2),
-      color: colors[Math.floor(Math.random() * colors.length)],
-      rotate: rotate > 0 ? (rotate + r / 20) * 10 : (rotate - r / 20) * 10,
+    const getXY = (
+        distance: number,
+        pointIndex: number,
+        totalPoints: number
+    ): [number, number] => {
+        const angle =
+            ((360 + noise(8)) / totalPoints) * pointIndex * (Math.PI / 180);
+        return [distance * Math.cos(angle), distance * Math.sin(angle)];
     };
-  };
 
-  const makeParticles = (element: HTMLElement) => {
-    const d: [number, number] = particleDistances;
-    const r = particleR;
-    const bubbleTime = animationTime * 2 + timeVariance;
-    element.style.setProperty("--time", `${bubbleTime}ms`);
+    const createParticle = (
+        i: number,
+        t: number,
+        d: [number, number],
+        r: number
+    ) => {
+        let rotate = noise(r / 10);
+        return {
+            start: getXY(d[0], particleCount - i, particleCount),
+            end: getXY(d[1] + noise(7), particleCount - i, particleCount),
+            time: t,
+            scale: 1 + noise(0.2),
+            color: colors[Math.floor(Math.random() * colors.length)],
+            rotate:
+                rotate > 0 ? (rotate + r / 20) * 10 : (rotate - r / 20) * 10,
+        };
+    };
 
-    for (let i = 0; i < particleCount; i++) {
-      const t = animationTime * 2 + noise(timeVariance * 2);
-      const p = createParticle(i, t, d, r);
-      element.classList.remove("active");
+    const makeParticles = (element: HTMLElement) => {
+        const d: [number, number] = particleDistances;
+        const r = particleR;
+        const bubbleTime = animationTime * 2 + timeVariance;
+        element.style.setProperty("--time", `${bubbleTime}ms`);
 
-      setTimeout(() => {
-        const particle = document.createElement("span");
-        const point = document.createElement("span");
-        particle.classList.add("particle");
-        particle.style.setProperty("--start-x", `${p.start[0]}px`);
-        particle.style.setProperty("--start-y", `${p.start[1]}px`);
-        particle.style.setProperty("--end-x", `${p.end[0]}px`);
-        particle.style.setProperty("--end-y", `${p.end[1]}px`);
-        particle.style.setProperty("--time", `${p.time}ms`);
-        particle.style.setProperty("--scale", `${p.scale}`);
-        particle.style.setProperty("--color", `var(--color-${p.color}, white)`);
-        particle.style.setProperty("--rotate", `${p.rotate}deg`);
+        for (let i = 0; i < particleCount; i++) {
+            const t = animationTime * 2 + noise(timeVariance * 2);
+            const p = createParticle(i, t, d, r);
+            element.classList.remove("active");
 
-        point.classList.add("point");
-        particle.appendChild(point);
-        element.appendChild(particle);
-        requestAnimationFrame(() => {
-          element.classList.add("active");
+            setTimeout(() => {
+                const particle = document.createElement("span");
+                const point = document.createElement("span");
+                particle.classList.add("particle");
+                particle.style.setProperty("--start-x", `${p.start[0]}px`);
+                particle.style.setProperty("--start-y", `${p.start[1]}px`);
+                particle.style.setProperty("--end-x", `${p.end[0]}px`);
+                particle.style.setProperty("--end-y", `${p.end[1]}px`);
+                particle.style.setProperty("--time", `${p.time}ms`);
+                particle.style.setProperty("--scale", `${p.scale}`);
+                particle.style.setProperty(
+                    "--color",
+                    `var(--color-${p.color}, white)`
+                );
+                particle.style.setProperty("--rotate", `${p.rotate}deg`);
+
+                point.classList.add("point");
+                particle.appendChild(point);
+                element.appendChild(particle);
+                requestAnimationFrame(() => {
+                    element.classList.add("active");
+                });
+                setTimeout(() => {
+                    try {
+                        element.removeChild(particle);
+                    } catch {
+                        // Do nothing
+                    }
+                }, t);
+            }, 30);
+        }
+    };
+
+    const updateEffectPosition = (element: HTMLElement) => {
+        if (!containerRef.current || !filterRef.current || !textRef.current)
+            return;
+        const containerRect = containerRef.current.getBoundingClientRect();
+        const pos = element.getBoundingClientRect();
+
+        const styles = {
+            left: `${pos.x - containerRect.x}px`,
+            top: `${pos.y - containerRect.y}px`,
+            width: `${pos.width}px`,
+            height: `${pos.height}px`,
+        };
+        Object.assign(filterRef.current.style, styles);
+        Object.assign(textRef.current.style, styles);
+        textRef.current.innerText = element.innerText;
+    };
+
+    const handleClick = (
+        e: React.MouseEvent<HTMLAnchorElement>,
+        index: number
+    ) => {
+        const liEl = e.currentTarget;
+        if (activeIndex === index) return;
+
+        setActiveIndex(index);
+        updateEffectPosition(liEl);
+
+        if (filterRef.current) {
+            const particles = filterRef.current.querySelectorAll(".particle");
+            particles.forEach((p) => filterRef.current!.removeChild(p));
+        }
+
+        if (textRef.current) {
+            textRef.current.classList.remove("active");
+
+            void textRef.current.offsetWidth;
+            textRef.current.classList.add("active");
+        }
+
+        if (filterRef.current) {
+            makeParticles(filterRef.current);
+        }
+    };
+
+    const handleKeyDown = (
+        e: React.KeyboardEvent<HTMLAnchorElement>,
+        index: number
+    ) => {
+        if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            const liEl = e.currentTarget.parentElement;
+            if (liEl) {
+                handleClick(
+                    {
+                        currentTarget: liEl,
+                    } as React.MouseEvent<HTMLAnchorElement>,
+                    index
+                );
+            }
+        }
+    };
+
+    useEffect(() => {
+        if (!navRef.current || !containerRef.current) return;
+        const activeLi = navRef.current.querySelectorAll("li")[
+            activeIndex
+        ] as HTMLElement;
+        if (activeLi) {
+            updateEffectPosition(activeLi);
+            textRef.current?.classList.add("active");
+        }
+
+        const resizeObserver = new ResizeObserver(() => {
+            const currentActiveLi = navRef.current?.querySelectorAll("li")[
+                activeIndex
+            ] as HTMLElement;
+            if (currentActiveLi) {
+                updateEffectPosition(currentActiveLi);
+            }
         });
-        setTimeout(() => {
-          try {
-            element.removeChild(particle);
-          } catch {
-            // Do nothing
-          }
-        }, t);
-      }, 30);
-    }
-  };
 
-  const updateEffectPosition = (element: HTMLElement) => {
-    if (!containerRef.current || !filterRef.current || !textRef.current) return;
-    const containerRect = containerRef.current.getBoundingClientRect();
-    const pos = element.getBoundingClientRect();
+        resizeObserver.observe(containerRef.current);
+        return () => resizeObserver.disconnect();
+    }, [activeIndex]);
 
-    const styles = {
-      left: `${pos.x - containerRect.x}px`,
-      top: `${pos.y - containerRect.y}px`,
-      width: `${pos.width}px`,
-      height: `${pos.height}px`,
-    };
-    Object.assign(filterRef.current.style, styles);
-    Object.assign(textRef.current.style, styles);
-    textRef.current.innerText = element.innerText;
-  };
-
-  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>, index: number) => {
-    const liEl = e.currentTarget;
-    if (activeIndex === index) return;
-
-    setActiveIndex(index);
-    updateEffectPosition(liEl);
-
-    if (filterRef.current) {
-      const particles = filterRef.current.querySelectorAll(".particle");
-      particles.forEach((p) => filterRef.current!.removeChild(p));
-    }
-
-    if (textRef.current) {
-      textRef.current.classList.remove("active");
-
-      void textRef.current.offsetWidth;
-      textRef.current.classList.add("active");
-    }
-
-    if (filterRef.current) {
-      makeParticles(filterRef.current);
-    }
-  };
-
-  const handleKeyDown = (
-    e: React.KeyboardEvent<HTMLAnchorElement>,
-    index: number
-  ) => {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      const liEl = e.currentTarget.parentElement;
-      if (liEl) {
-        handleClick(
-          { currentTarget: liEl } as React.MouseEvent<HTMLAnchorElement>,
-          index
-        );
-      }
-    }
-  };
-
-  useEffect(() => {
-    if (!navRef.current || !containerRef.current) return;
-    const activeLi = navRef.current.querySelectorAll("li")[
-      activeIndex
-    ] as HTMLElement;
-    if (activeLi) {
-      updateEffectPosition(activeLi);
-      textRef.current?.classList.add("active");
-    }
-
-    const resizeObserver = new ResizeObserver(() => {
-      const currentActiveLi = navRef.current?.querySelectorAll("li")[
-        activeIndex
-      ] as HTMLElement;
-      if (currentActiveLi) {
-        updateEffectPosition(currentActiveLi);
-      }
-    });
-
-    resizeObserver.observe(containerRef.current);
-    return () => resizeObserver.disconnect();
-  }, [activeIndex]);
-
-  return (
-    <div className="gooey-nav-container" ref={containerRef}>
-      <nav>
-        <ul ref={navRef}>
-          {items.map((item, index) => (
-            <li
-              key={index}
-              className={activeIndex === index ? "active" : ""}
-            >
-              <a href={item.href} onClick={(e) => handleClick(e, index)} onKeyDown={(e) => handleKeyDown(e, index)}>
-                {item.label}
-              </a>
-            </li>
-          ))}
-        </ul>
-      </nav>
-      <span className="effect filter" ref={filterRef} />
-      <span className="effect text" ref={textRef} />
-    </div>
-  );
+    return (
+        <div className="gooey-nav-container" ref={containerRef}>
+            <nav>
+                <ul ref={navRef}>
+                    {items.map((item, index) => (
+                        <li
+                            key={index}
+                            className={activeIndex === index ? "active" : ""}
+                        >
+                            <a
+                                href={item.href}
+                                onClick={(e) => handleClick(e, index)}
+                                onKeyDown={(e) => handleKeyDown(e, index)}
+                            >
+                                {item.label}
+                            </a>
+                        </li>
+                    ))}
+                </ul>
+            </nav>
+            <span className="effect filter" ref={filterRef} />
+            <span className="effect text" ref={textRef} />
+        </div>
+    );
 };
 
 export default GooeyNav;

--- a/src/ts-default/Components/GooeyNav/GooeyNav.tsx
+++ b/src/ts-default/Components/GooeyNav/GooeyNav.tsx
@@ -190,9 +190,8 @@ const GooeyNav: React.FC<GooeyNavProps> = ({
             <li
               key={index}
               className={activeIndex === index ? "active" : ""}
-              onClick={(e) => handleClick(e, index)}
             >
-              <a href={item.href} onKeyDown={(e) => handleKeyDown(e, index)}>
+              <a href={item.href} onClick={(e) => handleClick(e, index)} onKeyDown={(e) => handleKeyDown(e, index)}>
                 {item.label}
               </a>
             </li>

--- a/src/ts-default/Components/GooeyNav/GooeyNav.tsx
+++ b/src/ts-default/Components/GooeyNav/GooeyNav.tsx
@@ -119,7 +119,7 @@ const GooeyNav: React.FC<GooeyNavProps> = ({
     textRef.current.innerText = element.innerText;
   };
 
-  const handleClick = (e: React.MouseEvent<HTMLLIElement>, index: number) => {
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>, index: number) => {
     const liEl = e.currentTarget;
     if (activeIndex === index) return;
 
@@ -152,7 +152,7 @@ const GooeyNav: React.FC<GooeyNavProps> = ({
       const liEl = e.currentTarget.parentElement;
       if (liEl) {
         handleClick(
-          { currentTarget: liEl } as React.MouseEvent<HTMLLIElement>,
+          { currentTarget: liEl } as React.MouseEvent<HTMLAnchorElement>,
           index
         );
       }

--- a/src/ts-default/Components/GooeyNav/GooeyNav.tsx
+++ b/src/ts-default/Components/GooeyNav/GooeyNav.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import "./GooeyNav.css";
 
 interface GooeyNavItem {

--- a/src/ts-default/Components/GooeyNav/GooeyNav.tsx
+++ b/src/ts-default/Components/GooeyNav/GooeyNav.tsx
@@ -192,7 +192,6 @@ const GooeyNav: React.FC<GooeyNavProps> = ({
         return () => resizeObserver.disconnect();
     }, [activeIndex]);
 
-<<<<<<< HEAD
     return (
         <div className="gooey-nav-container" ref={containerRef}>
             <nav>
@@ -217,103 +216,6 @@ const GooeyNav: React.FC<GooeyNavProps> = ({
             <span className="effect text" ref={textRef} />
         </div>
     );
-=======
-    const styles = {
-      left: `${pos.x - containerRect.x}px`,
-      top: `${pos.y - containerRect.y}px`,
-      width: `${pos.width}px`,
-      height: `${pos.height}px`,
-    };
-    Object.assign(filterRef.current.style, styles);
-    Object.assign(textRef.current.style, styles);
-    textRef.current.innerText = element.innerText;
-  };
-
-  const handleClick = (e: React.MouseEvent<HTMLLIElement>, index: number) => {
-    const liEl = e.currentTarget;
-    if (activeIndex === index) return;
-
-    setActiveIndex(index);
-    updateEffectPosition(liEl);
-
-    if (filterRef.current) {
-      const particles = filterRef.current.querySelectorAll(".particle");
-      particles.forEach((p) => filterRef.current!.removeChild(p));
-    }
-
-    if (textRef.current) {
-      textRef.current.classList.remove("active");
-
-      void textRef.current.offsetWidth;
-      textRef.current.classList.add("active");
-    }
-
-    if (filterRef.current) {
-      makeParticles(filterRef.current);
-    }
-  };
-
-  const handleKeyDown = (
-    e: React.KeyboardEvent<HTMLAnchorElement>,
-    index: number
-  ) => {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      const liEl = e.currentTarget.parentElement;
-      if (liEl) {
-        handleClick(
-          { currentTarget: liEl } as React.MouseEvent<HTMLLIElement>,
-          index
-        );
-      }
-    }
-  };
-
-  useEffect(() => {
-    if (!navRef.current || !containerRef.current) return;
-    const activeLi = navRef.current.querySelectorAll("li")[
-      activeIndex
-    ] as HTMLElement;
-    if (activeLi) {
-      updateEffectPosition(activeLi);
-      textRef.current?.classList.add("active");
-    }
-
-    const resizeObserver = new ResizeObserver(() => {
-      const currentActiveLi = navRef.current?.querySelectorAll("li")[
-        activeIndex
-      ] as HTMLElement;
-      if (currentActiveLi) {
-        updateEffectPosition(currentActiveLi);
-      }
-    });
-
-    resizeObserver.observe(containerRef.current);
-    return () => resizeObserver.disconnect();
-  }, [activeIndex]);
-
-  return (
-    <div className="gooey-nav-container" ref={containerRef}>
-      <nav>
-        <ul ref={navRef}>
-          {items.map((item, index) => (
-            <li key={index} className={activeIndex === index ? "active" : ""}>
-              <a
-                href={item.href}
-                onClick={(e) => handleClick(e, index)}
-                onKeyDown={(e) => handleKeyDown(e, index)}
-              >
-                {item.label}
-              </a>
-            </li>
-          ))}
-        </ul>
-      </nav>
-      <span className="effect filter" ref={filterRef} />
-      <span className="effect text" ref={textRef} />
-    </div>
-  );
->>>>>>> fdaaed0bd6092848d81e96e9d10bf4c970d9362b
 };
 
 export default GooeyNav;

--- a/src/ts-default/Components/GooeyNav/GooeyNav.tsx
+++ b/src/ts-default/Components/GooeyNav/GooeyNav.tsx
@@ -143,6 +143,8 @@ const GooeyNav: React.FC<GooeyNavProps> = ({
     if (filterRef.current) {
       makeParticles(filterRef.current);
     }
+
+    navigate(items[index].href);
   };
 
   const handleKeyDown = (

--- a/src/ts-default/Components/GooeyNav/GooeyNav.tsx
+++ b/src/ts-default/Components/GooeyNav/GooeyNav.tsx
@@ -1,5 +1,4 @@
 import React, { useRef, useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
 import "./GooeyNav.css";
 
 interface GooeyNavItem {

--- a/src/ts-default/Components/GooeyNav/GooeyNav.tsx
+++ b/src/ts-default/Components/GooeyNav/GooeyNav.tsx
@@ -32,7 +32,6 @@ const GooeyNav: React.FC<GooeyNavProps> = ({
   const filterRef = useRef<HTMLSpanElement>(null);
   const textRef = useRef<HTMLSpanElement>(null);
   const [activeIndex, setActiveIndex] = useState<number>(initialActiveIndex);
-  const navigate = useNavigate();
 
   const noise = (n = 1) => n / 2 - Math.random() * n;
 
@@ -142,8 +141,6 @@ const GooeyNav: React.FC<GooeyNavProps> = ({
     if (filterRef.current) {
       makeParticles(filterRef.current);
     }
-
-    navigate(items[index].href);
   };
 
   const handleKeyDown = (

--- a/src/ts-default/Components/GooeyNav/GooeyNav.tsx
+++ b/src/ts-default/Components/GooeyNav/GooeyNav.tsx
@@ -33,6 +33,7 @@ const GooeyNav: React.FC<GooeyNavProps> = ({
   const filterRef = useRef<HTMLSpanElement>(null);
   const textRef = useRef<HTMLSpanElement>(null);
   const [activeIndex, setActiveIndex] = useState<number>(initialActiveIndex);
+  const navigate = useNavigate();
 
   const noise = (n = 1) => n / 2 - Math.random() * n;
 

--- a/src/ts-tailwind/Components/GooeyNav/GooeyNav.tsx
+++ b/src/ts-tailwind/Components/GooeyNav/GooeyNav.tsx
@@ -318,7 +318,7 @@ const GooeyNav: React.FC<GooeyNavProps> = ({
             {items.map((item, index) => (
               <li
                 key={index}
-                className={`py-[0.6em] px-[1em] rounded-full relative cursor-pointer transition-[background-color_color_box-shadow] duration-300 ease shadow-[0_0_0.5px_1.5px_transparent] text-white ${
+                className={`rounded-full relative cursor-pointer transition-[background-color_color_box-shadow] duration-300 ease shadow-[0_0_0.5px_1.5px_transparent] text-white ${
                   activeIndex === index ? "active" : ""
                 }`}
                 >
@@ -326,7 +326,7 @@ const GooeyNav: React.FC<GooeyNavProps> = ({
                   href={item.href}
                   onClick={(e) => handleClick(e, index)}
                   onKeyDown={(e) => handleKeyDown(e, index)}
-                  className="outline-none"
+                  className="outline-none py-[0.6em] px-[1em] inline-block"
                 >
                   {item.label}
                 </a>

--- a/src/ts-tailwind/Components/GooeyNav/GooeyNav.tsx
+++ b/src/ts-tailwind/Components/GooeyNav/GooeyNav.tsx
@@ -1,5 +1,4 @@
 import React, { useRef, useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
 
 interface GooeyNavItem {
   label: string;

--- a/src/ts-tailwind/Components/GooeyNav/GooeyNav.tsx
+++ b/src/ts-tailwind/Components/GooeyNav/GooeyNav.tsx
@@ -32,6 +32,8 @@ const GooeyNav: React.FC<GooeyNavProps> = ({
   const filterRef = useRef<HTMLSpanElement>(null);
   const textRef = useRef<HTMLSpanElement>(null);
   const [activeIndex, setActiveIndex] = useState<number>(initialActiveIndex);
+  const navigate = useNavigate();
+  
   const noise = (n = 1) => n / 2 - Math.random() * n;
   const getXY = (
     distance: number,

--- a/src/ts-tailwind/Components/GooeyNav/GooeyNav.tsx
+++ b/src/ts-tailwind/Components/GooeyNav/GooeyNav.tsx
@@ -321,10 +321,10 @@ const GooeyNav: React.FC<GooeyNavProps> = ({
                 className={`py-[0.6em] px-[1em] rounded-full relative cursor-pointer transition-[background-color_color_box-shadow] duration-300 ease shadow-[0_0_0.5px_1.5px_transparent] text-white ${
                   activeIndex === index ? "active" : ""
                 }`}
-                onClick={(e) => handleClick(e, index)}
-              >
+                >
                 <a
                   href={item.href}
+                  onClick={(e) => handleClick(e, index)}
                   onKeyDown={(e) => handleKeyDown(e, index)}
                   className="outline-none"
                 >

--- a/src/ts-tailwind/Components/GooeyNav/GooeyNav.tsx
+++ b/src/ts-tailwind/Components/GooeyNav/GooeyNav.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 
 interface GooeyNavItem {
   label: string;

--- a/src/ts-tailwind/Components/GooeyNav/GooeyNav.tsx
+++ b/src/ts-tailwind/Components/GooeyNav/GooeyNav.tsx
@@ -126,6 +126,8 @@ const GooeyNav: React.FC<GooeyNavProps> = ({
     if (filterRef.current) {
       makeParticles(filterRef.current);
     }
+
+    navigate(items[index].href);
   };
   const handleKeyDown = (
     e: React.KeyboardEvent<HTMLAnchorElement>,

--- a/src/ts-tailwind/Components/GooeyNav/GooeyNav.tsx
+++ b/src/ts-tailwind/Components/GooeyNav/GooeyNav.tsx
@@ -31,7 +31,6 @@ const GooeyNav: React.FC<GooeyNavProps> = ({
   const filterRef = useRef<HTMLSpanElement>(null);
   const textRef = useRef<HTMLSpanElement>(null);
   const [activeIndex, setActiveIndex] = useState<number>(initialActiveIndex);
-  const navigate = useNavigate();
   
   const noise = (n = 1) => n / 2 - Math.random() * n;
   const getXY = (
@@ -125,8 +124,6 @@ const GooeyNav: React.FC<GooeyNavProps> = ({
     if (filterRef.current) {
       makeParticles(filterRef.current);
     }
-
-    navigate(items[index].href);
   };
   const handleKeyDown = (
     e: React.KeyboardEvent<HTMLAnchorElement>,

--- a/src/ts-tailwind/Components/GooeyNav/GooeyNav.tsx
+++ b/src/ts-tailwind/Components/GooeyNav/GooeyNav.tsx
@@ -1,171 +1,181 @@
 import React, { useRef, useEffect, useState } from "react";
 
 interface GooeyNavItem {
-  label: string;
-  href: string;
+    label: string;
+    href: string;
 }
 
 export interface GooeyNavProps {
-  items: GooeyNavItem[];
-  animationTime?: number;
-  particleCount?: number;
-  particleDistances?: [number, number];
-  particleR?: number;
-  timeVariance?: number;
-  colors?: number[];
-  initialActiveIndex?: number;
+    items: GooeyNavItem[];
+    animationTime?: number;
+    particleCount?: number;
+    particleDistances?: [number, number];
+    particleR?: number;
+    timeVariance?: number;
+    colors?: number[];
+    initialActiveIndex?: number;
 }
 
 const GooeyNav: React.FC<GooeyNavProps> = ({
-  items,
-  animationTime = 600,
-  particleCount = 15,
-  particleDistances = [90, 10],
-  particleR = 100,
-  timeVariance = 300,
-  colors = [1, 2, 3, 1, 2, 3, 1, 4],
-  initialActiveIndex = 0,
+    items,
+    animationTime = 600,
+    particleCount = 15,
+    particleDistances = [90, 10],
+    particleR = 100,
+    timeVariance = 300,
+    colors = [1, 2, 3, 1, 2, 3, 1, 4],
+    initialActiveIndex = 0,
 }) => {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const navRef = useRef<HTMLUListElement>(null);
-  const filterRef = useRef<HTMLSpanElement>(null);
-  const textRef = useRef<HTMLSpanElement>(null);
-  const [activeIndex, setActiveIndex] = useState<number>(initialActiveIndex);
-  
-  const noise = (n = 1) => n / 2 - Math.random() * n;
-  const getXY = (
-    distance: number,
-    pointIndex: number,
-    totalPoints: number
-  ): [number, number] => {
-    const angle =
-      ((360 + noise(8)) / totalPoints) * pointIndex * (Math.PI / 180);
-    return [distance * Math.cos(angle), distance * Math.sin(angle)];
-  };
-  const createParticle = (
-    i: number,
-    t: number,
-    d: [number, number],
-    r: number
-  ) => {
-    let rotate = noise(r / 10);
-    return {
-      start: getXY(d[0], particleCount - i, particleCount),
-      end: getXY(d[1] + noise(7), particleCount - i, particleCount),
-      time: t,
-      scale: 1 + noise(0.2),
-      color: colors[Math.floor(Math.random() * colors.length)],
-      rotate: rotate > 0 ? (rotate + r / 20) * 10 : (rotate - r / 20) * 10,
-    };
-  };
-  const makeParticles = (element: HTMLElement) => {
-    const d: [number, number] = particleDistances;
-    const r = particleR;
-    const bubbleTime = animationTime * 2 + timeVariance;
-    element.style.setProperty("--time", `${bubbleTime}ms`);
-    for (let i = 0; i < particleCount; i++) {
-      const t = animationTime * 2 + noise(timeVariance * 2);
-      const p = createParticle(i, t, d, r);
-      element.classList.remove("active");
-      setTimeout(() => {
-        const particle = document.createElement("span");
-        const point = document.createElement("span");
-        particle.classList.add("particle");
-        particle.style.setProperty("--start-x", `${p.start[0]}px`);
-        particle.style.setProperty("--start-y", `${p.start[1]}px`);
-        particle.style.setProperty("--end-x", `${p.end[0]}px`);
-        particle.style.setProperty("--end-y", `${p.end[1]}px`);
-        particle.style.setProperty("--time", `${p.time}ms`);
-        particle.style.setProperty("--scale", `${p.scale}`);
-        particle.style.setProperty("--color", `var(--color-${p.color}, white)`);
-        particle.style.setProperty("--rotate", `${p.rotate}deg`);
-        point.classList.add("point");
-        particle.appendChild(point);
-        element.appendChild(particle);
-        requestAnimationFrame(() => {
-          element.classList.add("active");
-        });
-        setTimeout(() => {
-          try {
-            element.removeChild(particle);
-          } catch {}
-        }, t);
-      }, 30);
-    }
-  };
-  const updateEffectPosition = (element: HTMLElement) => {
-    if (!containerRef.current || !filterRef.current || !textRef.current) return;
-    const containerRect = containerRef.current.getBoundingClientRect();
-    const pos = element.getBoundingClientRect();
-    const styles = {
-      left: `${pos.x - containerRect.x}px`,
-      top: `${pos.y - containerRect.y}px`,
-      width: `${pos.width}px`,
-      height: `${pos.height}px`,
-    };
-    Object.assign(filterRef.current.style, styles);
-    Object.assign(textRef.current.style, styles);
-    textRef.current.innerText = element.innerText;
-  };
-  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>, index: number) => {
-    const liEl = e.currentTarget;
-    if (activeIndex === index) return;
-    setActiveIndex(index);
-    updateEffectPosition(liEl);
-    if (filterRef.current) {
-      const particles = filterRef.current.querySelectorAll(".particle");
-      particles.forEach((p) => filterRef.current!.removeChild(p));
-    }
-    if (textRef.current) {
-      textRef.current.classList.remove("active");
-      void textRef.current.offsetWidth;
-      textRef.current.classList.add("active");
-    }
-    if (filterRef.current) {
-      makeParticles(filterRef.current);
-    }
-  };
-  const handleKeyDown = (
-    e: React.KeyboardEvent<HTMLAnchorElement>,
-    index: number
-  ) => {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      const liEl = e.currentTarget.parentElement;
-      if (liEl) {
-        handleClick(
-          { currentTarget: liEl } as React.MouseEvent<HTMLAnchorElement>,
-          index
-        );
-      }
-    }
-  };
-  useEffect(() => {
-    if (!navRef.current || !containerRef.current) return;
-    const activeLi = navRef.current.querySelectorAll("li")[
-      activeIndex
-    ] as HTMLElement;
-    if (activeLi) {
-      updateEffectPosition(activeLi);
-      textRef.current?.classList.add("active");
-    }
-    const resizeObserver = new ResizeObserver(() => {
-      const currentActiveLi = navRef.current?.querySelectorAll("li")[
-        activeIndex
-      ] as HTMLElement;
-      if (currentActiveLi) {
-        updateEffectPosition(currentActiveLi);
-      }
-    });
-    resizeObserver.observe(containerRef.current);
-    return () => resizeObserver.disconnect();
-  }, [activeIndex]);
+    const containerRef = useRef<HTMLDivElement>(null);
+    const navRef = useRef<HTMLUListElement>(null);
+    const filterRef = useRef<HTMLSpanElement>(null);
+    const textRef = useRef<HTMLSpanElement>(null);
+    const [activeIndex, setActiveIndex] = useState<number>(initialActiveIndex);
 
-  return (
-    <>
-      {/* This effect is quite difficult to recreate faithfully using Tailwind, so a style tag is a necessary workaround */}
-      <style>
-        {`
+    const noise = (n = 1) => n / 2 - Math.random() * n;
+    const getXY = (
+        distance: number,
+        pointIndex: number,
+        totalPoints: number
+    ): [number, number] => {
+        const angle =
+            ((360 + noise(8)) / totalPoints) * pointIndex * (Math.PI / 180);
+        return [distance * Math.cos(angle), distance * Math.sin(angle)];
+    };
+    const createParticle = (
+        i: number,
+        t: number,
+        d: [number, number],
+        r: number
+    ) => {
+        let rotate = noise(r / 10);
+        return {
+            start: getXY(d[0], particleCount - i, particleCount),
+            end: getXY(d[1] + noise(7), particleCount - i, particleCount),
+            time: t,
+            scale: 1 + noise(0.2),
+            color: colors[Math.floor(Math.random() * colors.length)],
+            rotate:
+                rotate > 0 ? (rotate + r / 20) * 10 : (rotate - r / 20) * 10,
+        };
+    };
+    const makeParticles = (element: HTMLElement) => {
+        const d: [number, number] = particleDistances;
+        const r = particleR;
+        const bubbleTime = animationTime * 2 + timeVariance;
+        element.style.setProperty("--time", `${bubbleTime}ms`);
+        for (let i = 0; i < particleCount; i++) {
+            const t = animationTime * 2 + noise(timeVariance * 2);
+            const p = createParticle(i, t, d, r);
+            element.classList.remove("active");
+            setTimeout(() => {
+                const particle = document.createElement("span");
+                const point = document.createElement("span");
+                particle.classList.add("particle");
+                particle.style.setProperty("--start-x", `${p.start[0]}px`);
+                particle.style.setProperty("--start-y", `${p.start[1]}px`);
+                particle.style.setProperty("--end-x", `${p.end[0]}px`);
+                particle.style.setProperty("--end-y", `${p.end[1]}px`);
+                particle.style.setProperty("--time", `${p.time}ms`);
+                particle.style.setProperty("--scale", `${p.scale}`);
+                particle.style.setProperty(
+                    "--color",
+                    `var(--color-${p.color}, white)`
+                );
+                particle.style.setProperty("--rotate", `${p.rotate}deg`);
+                point.classList.add("point");
+                particle.appendChild(point);
+                element.appendChild(particle);
+                requestAnimationFrame(() => {
+                    element.classList.add("active");
+                });
+                setTimeout(() => {
+                    try {
+                        element.removeChild(particle);
+                    } catch {}
+                }, t);
+            }, 30);
+        }
+    };
+    const updateEffectPosition = (element: HTMLElement) => {
+        if (!containerRef.current || !filterRef.current || !textRef.current)
+            return;
+        const containerRect = containerRef.current.getBoundingClientRect();
+        const pos = element.getBoundingClientRect();
+        const styles = {
+            left: `${pos.x - containerRect.x}px`,
+            top: `${pos.y - containerRect.y}px`,
+            width: `${pos.width}px`,
+            height: `${pos.height}px`,
+        };
+        Object.assign(filterRef.current.style, styles);
+        Object.assign(textRef.current.style, styles);
+        textRef.current.innerText = element.innerText;
+    };
+    const handleClick = (
+        e: React.MouseEvent<HTMLAnchorElement>,
+        index: number
+    ) => {
+        const liEl = e.currentTarget;
+        if (activeIndex === index) return;
+        setActiveIndex(index);
+        updateEffectPosition(liEl);
+        if (filterRef.current) {
+            const particles = filterRef.current.querySelectorAll(".particle");
+            particles.forEach((p) => filterRef.current!.removeChild(p));
+        }
+        if (textRef.current) {
+            textRef.current.classList.remove("active");
+            void textRef.current.offsetWidth;
+            textRef.current.classList.add("active");
+        }
+        if (filterRef.current) {
+            makeParticles(filterRef.current);
+        }
+    };
+    const handleKeyDown = (
+        e: React.KeyboardEvent<HTMLAnchorElement>,
+        index: number
+    ) => {
+        if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            const liEl = e.currentTarget.parentElement;
+            if (liEl) {
+                handleClick(
+                    {
+                        currentTarget: liEl,
+                    } as React.MouseEvent<HTMLAnchorElement>,
+                    index
+                );
+            }
+        }
+    };
+    useEffect(() => {
+        if (!navRef.current || !containerRef.current) return;
+        const activeLi = navRef.current.querySelectorAll("li")[
+            activeIndex
+        ] as HTMLElement;
+        if (activeLi) {
+            updateEffectPosition(activeLi);
+            textRef.current?.classList.add("active");
+        }
+        const resizeObserver = new ResizeObserver(() => {
+            const currentActiveLi = navRef.current?.querySelectorAll("li")[
+                activeIndex
+            ] as HTMLElement;
+            if (currentActiveLi) {
+                updateEffectPosition(currentActiveLi);
+            }
+        });
+        resizeObserver.observe(containerRef.current);
+        return () => resizeObserver.disconnect();
+    }, [activeIndex]);
+
+    return (
+        <>
+            {/* This effect is quite difficult to recreate faithfully using Tailwind, so a style tag is a necessary workaround */}
+            <style>
+                {`
           :root {
             --linear-ease: linear(0, 0.068, 0.19 2.7%, 0.804 8.1%, 1.037, 1.199 13.2%, 1.245, 1.27 15.8%, 1.274, 1.272 17.4%, 1.249 19.1%, 0.996 28%, 0.949, 0.928 33.3%, 0.926, 0.933 36.8%, 1.001 45.6%, 1.013, 1.019 50.8%, 1.018 54.4%, 1 63.1%, 0.995 68%, 1.001 85%, 1);
           }
@@ -301,44 +311,44 @@ const GooeyNav: React.FC<GooeyNavProps> = ({
             z-index: -1;
           }
         `}
-      </style>
-      <div className="relative" ref={containerRef}>
-        <nav
-          className="flex relative"
-          style={{ transform: "translate3d(0,0,0.01px)" }}
-        >
-          <ul
-            ref={navRef}
-            className="flex gap-8 list-none p-0 px-4 m-0 relative z-[3]"
-            style={{
-              color: "white",
-              textShadow: "0 1px 1px hsl(205deg 30% 10% / 0.2)",
-            }}
-          >
-            {items.map((item, index) => (
-              <li
-                key={index}
-                className={`rounded-full relative cursor-pointer transition-[background-color_color_box-shadow] duration-300 ease shadow-[0_0_0.5px_1.5px_transparent] text-white ${
-                  activeIndex === index ? "active" : ""
-                }`}
+            </style>
+            <div className="relative" ref={containerRef}>
+                <nav
+                    className="flex relative"
+                    style={{ transform: "translate3d(0,0,0.01px)" }}
                 >
-                <a
-                  href={item.href}
-                  onClick={(e) => handleClick(e, index)}
-                  onKeyDown={(e) => handleKeyDown(e, index)}
-                  className="outline-none py-[0.6em] px-[1em] inline-block"
-                >
-                  {item.label}
-                </a>
-              </li>
-            ))}
-          </ul>
-        </nav>
-        <span className="effect filter" ref={filterRef} />
-        <span className="effect text" ref={textRef} />
-      </div>
-    </>
-  );
+                    <ul
+                        ref={navRef}
+                        className="flex gap-8 list-none p-0 px-4 m-0 relative z-[3]"
+                        style={{
+                            color: "white",
+                            textShadow: "0 1px 1px hsl(205deg 30% 10% / 0.2)",
+                        }}
+                    >
+                        {items.map((item, index) => (
+                            <li
+                                key={index}
+                                className={`rounded-full relative cursor-pointer transition-[background-color_color_box-shadow] duration-300 ease shadow-[0_0_0.5px_1.5px_transparent] text-white ${
+                                    activeIndex === index ? "active" : ""
+                                }`}
+                            >
+                                <a
+                                    href={item.href}
+                                    onClick={(e) => handleClick(e, index)}
+                                    onKeyDown={(e) => handleKeyDown(e, index)}
+                                    className="outline-none py-[0.6em] px-[1em] inline-block"
+                                >
+                                    {item.label}
+                                </a>
+                            </li>
+                        ))}
+                    </ul>
+                </nav>
+                <span className="effect filter" ref={filterRef} />
+                <span className="effect text" ref={textRef} />
+            </div>
+        </>
+    );
 };
 
 export default GooeyNav;

--- a/src/ts-tailwind/Components/GooeyNav/GooeyNav.tsx
+++ b/src/ts-tailwind/Components/GooeyNav/GooeyNav.tsx
@@ -311,40 +311,11 @@ const GooeyNav: React.FC<GooeyNavProps> = ({
             z-index: -1;
           }
         `}
-<<<<<<< HEAD
             </style>
             <div className="relative" ref={containerRef}>
                 <nav
                     className="flex relative"
                     style={{ transform: "translate3d(0,0,0.01px)" }}
-=======
-      </style>
-      <div className="relative" ref={containerRef}>
-        <nav
-          className="flex relative"
-          style={{ transform: "translate3d(0,0,0.01px)" }}
-        >
-          <ul
-            ref={navRef}
-            className="flex gap-8 list-none p-0 px-4 m-0 relative z-[3]"
-            style={{
-              color: "white",
-              textShadow: "0 1px 1px hsl(205deg 30% 10% / 0.2)",
-            }}
-          >
-            {items.map((item, index) => (
-              <li
-                key={index}
-                className={`py-[0.6em] px-[1em] rounded-full relative transition-[background-color_color_box-shadow] duration-300 ease shadow-[0_0_0.5px_1.5px_transparent] text-white font-bold ${
-                  activeIndex === index ? "active" : ""
-                }`}
-              >
-                <a
-                  href={item.href}
-                  onClick={(e) => handleClick(e, index)}
-                  onKeyDown={(e) => handleKeyDown(e, index)}
-                  className="outline-none w-full h-full block cursor-pointer"
->>>>>>> fdaaed0bd6092848d81e96e9d10bf4c970d9362b
                 >
                     <ul
                         ref={navRef}

--- a/src/ts-tailwind/Components/GooeyNav/GooeyNav.tsx
+++ b/src/ts-tailwind/Components/GooeyNav/GooeyNav.tsx
@@ -107,7 +107,7 @@ const GooeyNav: React.FC<GooeyNavProps> = ({
     Object.assign(textRef.current.style, styles);
     textRef.current.innerText = element.innerText;
   };
-  const handleClick = (e: React.MouseEvent<HTMLLIElement>, index: number) => {
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>, index: number) => {
     const liEl = e.currentTarget;
     if (activeIndex === index) return;
     setActiveIndex(index);
@@ -134,7 +134,7 @@ const GooeyNav: React.FC<GooeyNavProps> = ({
       const liEl = e.currentTarget.parentElement;
       if (liEl) {
         handleClick(
-          { currentTarget: liEl } as React.MouseEvent<HTMLLIElement>,
+          { currentTarget: liEl } as React.MouseEvent<HTMLAnchorElement>,
           index
         );
       }


### PR DESCRIPTION
While working on Issue #294, I initially explored enhancing navigation behavior by using the `useNavigate` hook from `react-router-dom` inside the `<li>`'s click handler. 
- It worked well for **route-based navigation**, but:
  - ❌ It did **not support hash-based jumps** (e.g., `#about`, `#home`, `#contact`).
  - Since `useNavigate` doesn't trigger anchor-style scrolling, this approach was dropped before submitting a PR.

---

## 💡 Final Approach

After testing and refining, I went with a cleaner, style-based and DOM-structure approach that solves both navigation and animation issues:

### ✅ 1. Restructured Click Area for Reliable Navigation
- Moved `padding` from the `<li>` to the `<a>` tag.
- Applied `inline-block` to `<a>` so the entire visual area is now **clickable and navigable**, even for hash links.
- This uses native anchor behavior, which properly supports hash scrolling.

### ✅ 2. Fixed Animation Trigger
- Originally, the animation was triggered via an `onClick` on the `<li>`, which no longer worked once interaction was shifted to the `<a>`.
- Moved the `onClick` handler (for animation) to the `<a>`, ensuring both **animation and navigation work** seamlessly.

---

## 🧪 Tested Scenarios

- ✅ Route and Hash Jumps work as expected.
- ✅ Full `<li>` visual area responds to hover, click, and pointer styling.
- ✅ Animation effect triggers consistently.
- ✅ DOM structure is now semantically valid and hydration-safe.
