### PR TITLE
Update CLI installation command to reference AnimatedContent instead of AnimatedContainer

### DIFF
--- a/src/components/code/CliInstallation.jsx
+++ b/src/components/code/CliInstallation.jsx
@@ -94,7 +94,7 @@ const CliInstallation = ({
             </Text>
             <CodeHighlighter
               language="bash"
-              codeString="npx jsrepo add Animations/AnimatedContainer"
+              codeString="npx jsrepo add Animations/AnimatedContent"
             />
           </Accordion.ItemContent>
         </Accordion.Item>


### PR DESCRIPTION
### Summary

Replaced the outdated reference to `AnimatedContainer` with the correct `AnimatedContent` in the CLI installation command.

### Details

- Updated the CLI example (specify exact file or location).
- Verified the change appears correctly in the rendered documentation (if applicable).

---

Let me know if further adjustments are needed. Thanks for maintaining this great project!
