### PR TITLE
refactor: change variable declaration from let to const for start in DarkVeil component

### DIFF
--- a/src/content/Backgrounds/DarkVeil/DarkVeil.jsx
+++ b/src/content/Backgrounds/DarkVeil/DarkVeil.jsx
@@ -122,8 +122,8 @@ export default function DarkVeil({
     window.addEventListener("resize", resize);
     resize();
 
-    let start = performance.now(),
-      frame = 0;
+    const start = performance.now();
+    let frame = 0;
 
     const loop = () => {
       program.uniforms.uTime.value =

--- a/src/tailwind/Backgrounds/DarkVeil/DarkVeil.jsx
+++ b/src/tailwind/Backgrounds/DarkVeil/DarkVeil.jsx
@@ -121,8 +121,8 @@ export default function DarkVeil({
     window.addEventListener("resize", resize);
     resize();
 
-    let start = performance.now(),
-      frame = 0;
+    const start = performance.now();
+    let frame = 0;
 
     const loop = () => {
       program.uniforms.uTime.value =

--- a/src/ts-default/Backgrounds/DarkVeil/DarkVeil.tsx
+++ b/src/ts-default/Backgrounds/DarkVeil/DarkVeil.tsx
@@ -132,8 +132,8 @@ export default function DarkVeil({
     window.addEventListener("resize", resize);
     resize();
 
-    let start = performance.now(),
-      frame = 0;
+    const start = performance.now();
+    let frame = 0;
 
     const loop = () => {
       program.uniforms.uTime.value =

--- a/src/ts-tailwind/Backgrounds/DarkVeil/DarkVeil.tsx
+++ b/src/ts-tailwind/Backgrounds/DarkVeil/DarkVeil.tsx
@@ -131,8 +131,8 @@ export default function DarkVeil({
     window.addEventListener("resize", resize);
     resize();
 
-    let start = performance.now(),
-      frame = 0;
+    const start = performance.now();
+    let frame = 0;
 
     const loop = () => {
       program.uniforms.uTime.value =


### PR DESCRIPTION
### Summary

Refactored the `start` variable declaration in the `DarkVeil` component by changing it from `let` to `const`.

### Details

- This change improves code safety and consistency, as the `start` variable is not reassigned after initialization.
- In some environments or with certain TypeScript/ESLint configurations, this may also resolve a minor type error or warning about variable mutability.