### PR TITLE
Feat/Add mobile device tilt support to ProfileCard

### DIFF
--- a/src/constants/code/Components/profileCardCode.js
+++ b/src/constants/code/Components/profileCardCode.js
@@ -17,6 +17,7 @@ export const profileCard = {
   avatarUrl="/path/to/avatar.jpg"
   showUserInfo={true}
   enableTilt={true}
+  enableMobileTilt={false}
   onContactClick={() => console.log('Contact clicked')}
 />`,
   code,

--- a/src/content/Components/ProfileCard/ProfileCard.jsx
+++ b/src/content/Components/ProfileCard/ProfileCard.jsx
@@ -217,7 +217,7 @@ const ProfileCardComponent = ({
     const deviceOrientationHandler = handleDeviceOrientation;
 
     const handleClick = () => {
-      if (!enableMobileTilt) return;
+      if (!enableMobileTilt || location.protocol !== 'https:') return;
       if (typeof window.DeviceMotionEvent.requestPermission === 'function') {
         window.DeviceMotionEvent
           .requestPermission()

--- a/src/content/Components/ProfileCard/ProfileCard.jsx
+++ b/src/content/Components/ProfileCard/ProfileCard.jsx
@@ -12,6 +12,7 @@ const ANIMATION_CONFIG = {
   INITIAL_DURATION: 1500,
   INITIAL_X_OFFSET: 70,
   INITIAL_Y_OFFSET: 60,
+  DEVICE_BETA_OFFSET: 20,
 };
 
 const clamp = (value, min = 0, max = 100) =>
@@ -41,6 +42,8 @@ const ProfileCardComponent = ({
   showBehindGradient = true,
   className = "",
   enableTilt = true,
+  enableMobileTilt = false,
+  mobileTiltSensitivity = 5,
   miniAvatarUrl,
   name = "Javi A. Torres",
   title = "Software Engineer",
@@ -180,6 +183,26 @@ const ProfileCardComponent = ({
     [animationHandlers]
   );
 
+  const handleDeviceOrientation = useCallback(
+    (event) => {
+      const card = cardRef.current;
+      const wrap = wrapRef.current;
+
+      if (!card || !wrap || !animationHandlers) return;
+
+      const { beta, gamma } = event;
+      if (!beta || !gamma) return;
+
+      animationHandlers.updateCardTransform(
+        card.clientHeight / 2 + gamma * mobileTiltSensitivity,
+        card.clientWidth / 2 + (beta - ANIMATION_CONFIG.DEVICE_BETA_OFFSET) * mobileTiltSensitivity,
+        card,
+        wrap
+      );
+    },
+    [animationHandlers, mobileTiltSensitivity]
+  );
+
   useEffect(() => {
     if (!enableTilt || !animationHandlers) return;
 
@@ -191,10 +214,28 @@ const ProfileCardComponent = ({
     const pointerMoveHandler = handlePointerMove;
     const pointerEnterHandler = handlePointerEnter;
     const pointerLeaveHandler = handlePointerLeave;
+    const deviceOrientationHandler = handleDeviceOrientation;
+
+    const handleClick = () => {
+      if (!enableMobileTilt) return;
+      if (typeof window.DeviceMotionEvent.requestPermission === 'function') {
+        window.DeviceMotionEvent
+          .requestPermission()
+          .then(state => {
+            if (state === 'granted') {
+              window.addEventListener('deviceorientation', deviceOrientationHandler);
+            }
+          })
+          .catch(err => console.error(err));
+      } else {
+        window.addEventListener('deviceorientation', deviceOrientationHandler);
+      }
+    };
 
     card.addEventListener("pointerenter", pointerEnterHandler);
     card.addEventListener("pointermove", pointerMoveHandler);
     card.addEventListener("pointerleave", pointerLeaveHandler);
+    card.addEventListener("click", handleClick);
 
     const initialX = wrap.clientWidth - ANIMATION_CONFIG.INITIAL_X_OFFSET;
     const initialY = ANIMATION_CONFIG.INITIAL_Y_OFFSET;
@@ -212,14 +253,18 @@ const ProfileCardComponent = ({
       card.removeEventListener("pointerenter", pointerEnterHandler);
       card.removeEventListener("pointermove", pointerMoveHandler);
       card.removeEventListener("pointerleave", pointerLeaveHandler);
+      card.removeEventListener("click", handleClick);
+      window.removeEventListener('deviceorientation', deviceOrientationHandler);
       animationHandlers.cancelAnimation();
     };
   }, [
     enableTilt,
+    enableMobileTilt,
     animationHandlers,
     handlePointerMove,
     handlePointerEnter,
     handlePointerLeave,
+    handleDeviceOrientation,
   ]);
 
   const cardStyle = useMemo(

--- a/src/demo/Components/ProfileCardDemo.jsx
+++ b/src/demo/Components/ProfileCardDemo.jsx
@@ -16,6 +16,7 @@ const ProfileCardDemo = () => {
   const [showIcon, setShowIcon] = useState(true);
   const [showUserInfo, setShowUserInfo] = useState(true);
   const [showBehindGradient, setShowBehindGradient] = useState(true);
+  const [enableMobileTilt, setEnableMobileTilt] = useState(false);
   const [customBehindGradient, setCustomBehindGradient] = useState("radial-gradient(farthest-side circle at var(--pointer-x) var(--pointer-y),hsla(266,100%,90%,var(--card-opacity)) 4%,hsla(266,50%,80%,calc(var(--card-opacity)*0.75)) 10%,hsla(266,25%,70%,calc(var(--card-opacity)*0.5)) 50%,hsla(266,0%,60%,0) 100%),radial-gradient(35% 52% at 55% 20%,#00ffaac4 0%,#073aff00 100%),radial-gradient(100% 100% at 50% 50%,#00c1ffff 1%,#073aff00 76%),conic-gradient(from 124deg at 50% 50%,#c137ffff 0%,#07c6ffff 40%,#07c6ffff 60%,#c137ffff 100%)");
   const [customInnerGradient, setCustomInnerGradient] = useState("linear-gradient(145deg,#60496e8c 0%,#71C4FF44 100%)");
 
@@ -85,6 +86,18 @@ const ProfileCardDemo = () => {
       description: "Enable or disable the 3D tilt effect on mouse hover"
     },
     {
+      name: "enableMobileTilt",
+      type: "boolean",
+      default: "false",
+      description: "Enable or disable the 3D tilt effect on mobile devices"
+    },
+    {
+      name:"mobileTiltSensitivity",
+      type: "number",
+      default: "5",
+      description: "Sensitivity of the 3D tilt effect on mobile devices"
+    },
+    {
       name: "miniAvatarUrl",
       type: "string",
       default: "undefined",
@@ -152,6 +165,7 @@ const ProfileCardDemo = () => {
             grainUrl="/assets/grain.webp"
             behindGradient={customBehindGradient}
             innerGradient={customInnerGradient}
+            enableMobileTilt={enableMobileTilt}
           />
         </Box>        <Customize>
           <Button
@@ -188,6 +202,14 @@ const ProfileCardDemo = () => {
             isChecked={showBehindGradient}
             onChange={() => {
               setShowBehindGradient(!showBehindGradient);
+              forceRerender();
+            }}
+          />
+          <PreviewSwitch
+            title="Enable Mobile Tilt"
+            isChecked={enableMobileTilt}
+            onChange={() => {
+              setEnableMobileTilt(!enableMobileTilt);
               forceRerender();
             }}
           />

--- a/src/ts-default/Components/ProfileCard/ProfileCard.tsx
+++ b/src/ts-default/Components/ProfileCard/ProfileCard.tsx
@@ -10,6 +10,8 @@ interface ProfileCardProps {
   showBehindGradient?: boolean;
   className?: string;
   enableTilt?: boolean;
+  enableMobileTilt?: boolean;
+  mobileTiltSensitivity?: number;
   miniAvatarUrl?: string;
   name?: string;
   title?: string;
@@ -31,6 +33,7 @@ const ANIMATION_CONFIG = {
   INITIAL_DURATION: 1500,
   INITIAL_X_OFFSET: 70,
   INITIAL_Y_OFFSET: 60,
+  DEVICE_BETA_OFFSET: 20,
 } as const;
 
 const clamp = (value: number, min = 0, max = 100): number =>
@@ -60,6 +63,8 @@ const ProfileCardComponent: React.FC<ProfileCardProps> = ({
   showBehindGradient = true,
   className = "",
   enableTilt = true,
+  enableMobileTilt = false,
+  mobileTiltSensitivity = 5,
   miniAvatarUrl,
   name = "Javi A. Torres",
   title = "Software Engineer",
@@ -199,6 +204,26 @@ const ProfileCardComponent: React.FC<ProfileCardProps> = ({
     [animationHandlers]
   );
 
+  const handleDeviceOrientation = useCallback(
+    (event: DeviceOrientationEvent) => {
+      const card = cardRef.current;
+      const wrap = wrapRef.current;
+
+      if (!card || !wrap || !animationHandlers) return;
+
+      const { beta, gamma } = event;
+      if (!beta || !gamma) return;
+
+      animationHandlers.updateCardTransform(
+        card.clientHeight / 2 + gamma * mobileTiltSensitivity,
+        card.clientWidth / 2 + (beta - ANIMATION_CONFIG.DEVICE_BETA_OFFSET) * mobileTiltSensitivity,
+        card,
+        wrap
+      );
+    },
+    [animationHandlers, mobileTiltSensitivity]
+  );
+
   useEffect(() => {
     if (!enableTilt || !animationHandlers) return;
 
@@ -210,10 +235,28 @@ const ProfileCardComponent: React.FC<ProfileCardProps> = ({
     const pointerMoveHandler = handlePointerMove as EventListener;
     const pointerEnterHandler = handlePointerEnter as EventListener;
     const pointerLeaveHandler = handlePointerLeave as EventListener;
+    const deviceOrientationHandler = handleDeviceOrientation as EventListener;
+
+    const handleClick = () => {
+      if (!enableMobileTilt) return;
+      if (typeof (window.DeviceMotionEvent as any).requestPermission === 'function') {
+        (window.DeviceMotionEvent as any)
+          .requestPermission()
+          .then((state: string) => {
+            if (state === 'granted') {
+              window.addEventListener('deviceorientation', deviceOrientationHandler);
+            }
+          })
+          .catch((err: any) => console.error(err));
+      } else {
+        window.addEventListener('deviceorientation', deviceOrientationHandler);
+      }
+    };
 
     card.addEventListener("pointerenter", pointerEnterHandler);
     card.addEventListener("pointermove", pointerMoveHandler);
     card.addEventListener("pointerleave", pointerLeaveHandler);
+    card.addEventListener('click', handleClick);
 
     const initialX = wrap.clientWidth - ANIMATION_CONFIG.INITIAL_X_OFFSET;
     const initialY = ANIMATION_CONFIG.INITIAL_Y_OFFSET;
@@ -231,14 +274,18 @@ const ProfileCardComponent: React.FC<ProfileCardProps> = ({
       card.removeEventListener("pointerenter", pointerEnterHandler);
       card.removeEventListener("pointermove", pointerMoveHandler);
       card.removeEventListener("pointerleave", pointerLeaveHandler);
+      card.removeEventListener('click', handleClick);
+      window.removeEventListener('deviceorientation', deviceOrientationHandler);
       animationHandlers.cancelAnimation();
     };
   }, [
     enableTilt,
+    enableMobileTilt,
     animationHandlers,
     handlePointerMove,
     handlePointerEnter,
     handlePointerLeave,
+    handleDeviceOrientation,
   ]);
 
   const cardStyle = useMemo(

--- a/src/ts-default/Components/ProfileCard/ProfileCard.tsx
+++ b/src/ts-default/Components/ProfileCard/ProfileCard.tsx
@@ -238,7 +238,7 @@ const ProfileCardComponent: React.FC<ProfileCardProps> = ({
     const deviceOrientationHandler = handleDeviceOrientation as EventListener;
 
     const handleClick = () => {
-      if (!enableMobileTilt) return;
+      if (!enableMobileTilt || location.protocol !== 'https:') return;
       if (typeof (window.DeviceMotionEvent as any).requestPermission === 'function') {
         (window.DeviceMotionEvent as any)
           .requestPermission()


### PR DESCRIPTION
 ### feat(ProfileCard): Add mobile device tilt support
  This pull request introduces a 3D tilt effect for the ProfileCard component on mobile devices, responding to the device's orientation.

####  Description
  The effect is triggered by the device's gyroscope and accelerometer data. To respect user privacy and browser security policies, the tilt
  effect is only activated after the user clicks or taps on the card, which initiates the permission request for DeviceMotionEvent.


  **Note**: As of the latest commit, this feature is only available on sites served over HTTPS, as DeviceMotionEvent requires a secure context in
  most modern browsers.

 #### Key Changes


   - `ProfileCard.jsx` / `ProfileCard.tsx`:
       - Added two new props:
           - **enableMobileTilt** (boolean): To enable or disable the feature. Defaults to false.
           - **mobileTiltSensitivity** (number): To control how much the card tilts in response to device movement. Defaults to 5.
       - Implemented a handleDeviceOrientation event listener.
       - Added a click event handler to request the necessary permissions and activate the listener.
   - `ProfileCardDemo.jsx`:
       - Added a new "Enable Mobile Tilt" switch in the customization panel to allow for easy testing and demonstration of the feature.
   - `profileCardCode.js`:
       - Updated the code examples to include the new enableMobileTilt prop.

#### Reference Video
https://github.com/user-attachments/assets/21a2f36c-6dc7-480b-8b3e-968dbc758bfc

PS. I am not a native English speaker, so the property names may not be appropriate. If so, I will change them.