### PR TITLE
Feat/glare hover remove uneeded expression

### DIFF
--- a/src/tailwind/Animations/GlareHover/GlareHover.jsx
+++ b/src/tailwind/Animations/GlareHover/GlareHover.jsx
@@ -38,7 +38,6 @@ const GlareHover = ({
 
     el.style.transition = "none";
     el.style.backgroundPosition = "-100% -100%, 0 0";
-    el.offsetHeight;
     el.style.transition = `${transitionDuration}ms ease`;
     el.style.backgroundPosition = "100% 100%, 0 0";
   };

--- a/src/ts-tailwind/Animations/GlareHover/GlareHover.tsx
+++ b/src/ts-tailwind/Animations/GlareHover/GlareHover.tsx
@@ -55,7 +55,6 @@ const GlareHover: React.FC<GlareHoverProps> = ({
 
     el.style.transition = "none";
     el.style.backgroundPosition = "-100% -100%, 0 0";
-    el.offsetHeight;
     el.style.transition = `${transitionDuration}ms ease`;
     el.style.backgroundPosition = "100% 100%, 0 0";
   };


### PR DESCRIPTION
Addresses issue #353 

Seems like this line didn't serve any real purpose (unless it's there to show what _can_ be modified, in which case it should probably just be a comment instead).

This caused a linter error when using eslint, so since this line doesn't appear to actually change the offsetHeight of the element, it looks safe to remove. 