### PR TITLE
Fix See full snippet re-rendering

### DIFF
--- a/src/components/code/CodeExample.jsx
+++ b/src/components/code/CodeExample.jsx
@@ -1,4 +1,5 @@
 import { getLanguage } from "../../utils/utils";
+import { useState } from "react"; // << ADICIONADO
 import CodeHighlighter from "./CodeHighlighter";
 import CodeOptions, {
   CSSTab,
@@ -7,10 +8,14 @@ import CodeOptions, {
   TSTailwindTab,
 } from "./CodeOptions";
 
-const CodeExample = ({ codeObject }) => (
-  <>
-    {Object.entries(codeObject).map(([name, snippet]) => {
-      const skip = [
+const CodeExample = ({ codeObject }) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const handleToggleExpand = () => setIsExpanded((prev) => !prev);
+
+  return (
+    <>
+      {Object.entries(codeObject).map(([name, snippet]) => {
+        const skip = [
         "tailwind",
         "css",
         "tsTailwind",
@@ -26,35 +31,35 @@ const CodeExample = ({ codeObject }) => (
         return (
           <div key={name}>
             <h2 className="demo-title">{name}</h2>
-
+          {/* JS + TAILWIND */}
             <CodeOptions>
               <TailwindTab>
-                <CodeHighlighter language="jsx" codeString={codeObject.tailwind} />
+                <CodeHighlighter language="jsx" codeString={codeObject.tailwind} expanded={isExpanded} onToggleExpand={handleToggleExpand} />
               </TailwindTab>
-
+          {/* JS + Default CSS */}
               <CSSTab>
-                <CodeHighlighter language="jsx" codeString={codeObject.code} />
+                <CodeHighlighter language="jsx" codeString={codeObject.code} expanded={isExpanded} onToggleExpand={handleToggleExpand} />
                 {codeObject.css && (
                   <>
                     <h2 className="demo-title">CSS</h2>
-                    <CodeHighlighter language="css" codeString={codeObject.css} />
+                    <CodeHighlighter language="css" codeString={codeObject.css} expanded={isExpanded} onToggleExpand={handleToggleExpand} />
                   </>
                 )}
               </CSSTab>
-
+          {/* TS + TAILWIND */}
               {codeObject.tsTailwind && (
                 <TSTailwindTab>
-                  <CodeHighlighter language="tsx" codeString={codeObject.tsTailwind} />
+                  <CodeHighlighter language="tsx" codeString={codeObject.tsTailwind} expanded={isExpanded} onToggleExpand={handleToggleExpand} />
                 </TSTailwindTab>
               )}
-
+          {/* TS + Default CSS */}
               {codeObject.tsCode && (
                 <TSCSSTab>
-                  <CodeHighlighter language="tsx" codeString={codeObject.tsCode} />
+                  <CodeHighlighter language="tsx" codeString={codeObject.tsCode} expanded={isExpanded} onToggleExpand={handleToggleExpand} />
                   {codeObject.css && (
                     <>
                       <h2 className="demo-title">CSS</h2>
-                      <CodeHighlighter language="css" codeString={codeObject.css} />
+                      <CodeHighlighter language="css" codeString={codeObject.css} expanded={isExpanded} onToggleExpand={handleToggleExpand} />
                     </>
                   )}
                 </TSCSSTab>
@@ -67,11 +72,12 @@ const CodeExample = ({ codeObject }) => (
       return (
         <div key={name}>
           <h2 className="demo-title">{name}</h2>
-          <CodeHighlighter language={getLanguage(name)} codeString={snippet} />
+          <CodeHighlighter language={getLanguage(name)} codeString={snippet} expanded={isExpanded} onToggleExpand={handleToggleExpand} />
         </div>
       );
     })}
   </>
 );
+}
 
 export default CodeExample;

--- a/src/components/code/CodeExample.jsx
+++ b/src/components/code/CodeExample.jsx
@@ -1,5 +1,5 @@
 import { getLanguage } from "../../utils/utils";
-import { useState } from "react"; // << ADICIONADO
+import { useState } from "react"; 
 import CodeHighlighter from "./CodeHighlighter";
 import CodeOptions, {
   CSSTab,

--- a/src/components/code/CodeHighlighter.jsx
+++ b/src/components/code/CodeHighlighter.jsx
@@ -5,9 +5,8 @@ import { synthwave84 } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { FiCopy, FiCheckSquare } from "react-icons/fi";
 import { RiEmotionSadLine } from 'react-icons/ri';
 
-const CodeHighlighter = ({ language, codeString, showLineNumbers = true, maxLines = 25 }) => {
+const CodeHighlighter = ({ language, codeString, showLineNumbers = true, maxLines = 25, expanded, onToggleExpand }) => {
   const [copied, setCopied] = useState(false);
-  const [expanded, setExpanded] = useState(false);
 
   const handleCopy = async () => {
     try {
@@ -72,7 +71,7 @@ const CodeHighlighter = ({ language, codeString, showLineNumbers = true, maxLine
             _hover={{ backgroundColor: '#111' }}
             _active={{ backgroundColor: '#111' }}
             zIndex={2}
-            onClick={() => setExpanded(prev => !prev)}
+            onClick={onToggleExpand}
           >
             {expanded ? 'Collapse Snippet' : 'See Full Snippet'}
           </Button>


### PR DESCRIPTION
- **Fix:** Lifted the `isExpanded` state from `CodeHighlighter` to the parent `CodeExample` component. 
- **Why:** The previous behavior likely wasn't intentional, but I think specially for bug hunting/debugging/checking duplicate code, it is quite repetitive to click "See full snippet" every time you change the variant. For better experience, the user will only click once when he is checking a specific component.
- **Result:** Prevents the expanded view from resetting when the user switches between language or style tabs. (if the user reload the page or change the component, it will collapse as normal)

I also added some comments in CodeExample.jsx for easier readibility of each variant.