### PR TITLE
feat: remove unnecessary any type assertion in Aurora component

### DIFF
--- a/src/ts-default/Backgrounds/Aurora/Aurora.tsx
+++ b/src/ts-default/Backgrounds/Aurora/Aurora.tsx
@@ -158,7 +158,7 @@ export default function Aurora(props: AuroraProps) {
 
     const geometry = new Triangle(gl);
     if (geometry.attributes.uv) {
-      delete (geometry.attributes as any).uv;
+      delete (geometry.attributes).uv;
     }
 
     const colorStopsArray = colorStops.map((hex) => {


### PR DESCRIPTION
Remove redundant type assertion from geometry.attributes.uv deletion.
The OGL Triangle type definitions already support dynamic property deletion without requiring any type casting.

The `src/ts-tailwind/Backgrounds/Aurora/Aurora.tsx` is already right, the "any" is only on `src/ts-default/Backgrounds/Aurora/Aurora.tsx`
Before
<img width="509" height="377" alt="Screenshot 2025-08-02 at 11 11 19 PM" src="https://github.com/user-attachments/assets/7f0b08fe-2a06-4e7a-ba1d-cedf12816f5e" />


After
<img width="550" height="378" alt="Screenshot 2025-08-02 at 11 11 36 PM" src="https://github.com/user-attachments/assets/2ff491c0-946f-4253-8383-a2cc378dc377" />
