### PR TITLE
feat: remove unnecessary any type assertion in TextTrail component

### DIFF
--- a/src/ts-default/TextAnimations/TextTrail/TextTrail.tsx
+++ b/src/ts-default/TextAnimations/TextTrail/TextTrail.tsx
@@ -29,7 +29,7 @@ const hexToRgb = (hex: string): [number, number, number] => {
   return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
 };
 const loadFont = async (fam: string) => {
-  if ("fonts" in document) await (document as any).fonts.load(`64px "${fam}"`);
+  if ("fonts" in document) await document.fonts.load(`64px "${fam}"`);
 };
 
 const BASE_VERT = `

--- a/src/ts-tailwind/TextAnimations/TextTrail/TextTrail.tsx
+++ b/src/ts-tailwind/TextAnimations/TextTrail/TextTrail.tsx
@@ -27,7 +27,7 @@ const hexToRgb = (hex: string): [number, number, number] => {
   return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
 };
 const loadFont = async (fam: string) => {
-  if ("fonts" in document) await (document as any).fonts.load(`64px "${fam}"`);
+  if ("fonts" in document) await document.fonts.load(`64px "${fam}"`);
 };
 
 const BASE_VERT = `


### PR DESCRIPTION
The `document` object has the right type already, no need for "any"  😎

Before
<img width="633" height="152" alt="Screenshot 2025-08-04 at 11 11 04 AM" src="https://github.com/user-attachments/assets/27edd02b-2a51-4757-a929-b96082389f49" />

After
<img width="591" height="176" alt="Screenshot 2025-08-04 at 11 11 30 AM" src="https://github.com/user-attachments/assets/c6eb6239-c4f8-4643-a26a-3f422ec456ed" />


