### PR TITLE
feat: remove any from BlurText

### DIFF
--- a/src/ts-default/TextAnimations/BlurText/BlurText.tsx
+++ b/src/ts-default/TextAnimations/BlurText/BlurText.tsx
@@ -1,4 +1,5 @@
 import { motion, Transition } from 'framer-motion';
+import { EasingFunction } from 'motion-utils';
 import { useEffect, useRef, useState, useMemo } from 'react';
 
 type BlurTextProps = {
@@ -11,7 +12,7 @@ type BlurTextProps = {
   rootMargin?: string;
   animationFrom?: Record<string, string | number>;
   animationTo?: Array<Record<string, string | number>>;
-  easing?: (t: number) => number;
+  easing?: EasingFunction;
   onAnimationComplete?: () => void;
   stepDuration?: number;
 };
@@ -107,8 +108,8 @@ const BlurText: React.FC<BlurTextProps> = ({
           duration: totalDuration,
           times,
           delay: (index * delay) / 1000,
+          ease: easing,
         };
-        (spanTransition as any).ease = easing;
 
         return (
           <motion.span

--- a/src/ts-tailwind/TextAnimations/BlurText/BlurText.tsx
+++ b/src/ts-tailwind/TextAnimations/BlurText/BlurText.tsx
@@ -1,4 +1,5 @@
 import { motion, Transition } from "framer-motion";
+import { EasingFunction } from "motion-utils";
 import { useEffect, useRef, useState, useMemo } from "react";
 
 type BlurTextProps = {
@@ -11,7 +12,7 @@ type BlurTextProps = {
   rootMargin?: string;
   animationFrom?: Record<string, string | number>;
   animationTo?: Array<Record<string, string | number>>;
-  easing?: (t: number) => number;
+  easing?: EasingFunction;
   onAnimationComplete?: () => void;
   stepDuration?: number;
 };
@@ -103,8 +104,8 @@ const BlurText: React.FC<BlurTextProps> = ({
           duration: totalDuration,
           times,
           delay: (index * delay) / 1000,
+          ease: easing,
         };
-        (spanTransition as any).ease = easing;
 
         return (
           <motion.span


### PR DESCRIPTION
The type added has the same signature as the previous one `(t: number) => number`

<img width="542" height="405" alt="Screenshot 2025-08-05 at 11 13 39 AM" src="https://github.com/user-attachments/assets/0c57d7ae-70c7-4521-9b38-3c8007af0236" />


