### PR TITLE
fix: remove curly brackets from mcp server configuration codeblock for easier implementation

### DIFF
--- a/src/docs/McpServer.jsx
+++ b/src/docs/McpServer.jsx
@@ -63,12 +63,12 @@ const McpServer = () => {
           </p>
 
           <CodeBlock showLineNumbers={true}>
-{`{
+{`
   "react-bits-mcp": {
     "command": "npx",
     "args": ["mcp-remote", "https://react-bits-mcp.davidhzdev.workers.dev/sse"]
   }
-}`}
+`}
           </CodeBlock>
 
           <h4 className="docs-category-subtitle">3. Enable the MCP Server</h4>


### PR DESCRIPTION
With the current documentation (using Cursor), copy & pasting the current MCP server configuration into the mcp.json file breaks: 
<img width="649" height="168" alt="Screenshot 2025-08-13 at 1 49 13 AM" src="https://github.com/user-attachments/assets/165ca5e6-dcf8-483e-a8cb-e5bbf5cc07ee" />

Removing the first and last curly bracket solves this, as MCP configuration now looks like: { "mcpServers": { "react-bits-mcp": { "command": "npx", "args": ["mcp-remote", "https://react-bits-mcp.davidhzdev.workers.dev/sse"] } } }