### PR TITLE
Fix: Add null checks for rendererRef and canvasRef to prevent server crash

### DIFF
--- a/src/components/landing/PlasmaWave/PlasmaWaveV2.jsx
+++ b/src/components/landing/PlasmaWave/PlasmaWaveV2.jsx
@@ -160,7 +160,9 @@ export default function PlasmaWaveV2({
     if (isMobile) {
       return;
     }
-
+    if (!rendererRef.current) {
+      return;
+    }
     const renderer = new Renderer({
       alpha: true,
       dpr: Math.min(window.devicePixelRatio, 1),

--- a/src/content/Backgrounds/LetterGlitch/LetterGlitch.jsx
+++ b/src/content/Backgrounds/LetterGlitch/LetterGlitch.jsx
@@ -102,6 +102,9 @@ const LetterGlitch = ({
 
   const drawLetters = () => {
     if (!context.current || letters.current.length === 0) return;
+    if (!canvasRef.current) {
+      return;
+    }
     const ctx = context.current;
     const { width, height } = canvasRef.current.getBoundingClientRect();
     ctx.clearRect(0, 0, width, height);


### PR DESCRIPTION
This PR fixes server crashes caused by missing ref objects in two components:
	•	PlasmaWaveV2: Added null check for rendererRef.
	•	LetterGlitch: Added null check for canvasRef.

Previously, when either rendererRef or canvasRef was null, the server would crash unexpectedly. With these changes, both components now safely exit early if the ref is not available.

Closes #406