### PR TITLE
fix: suppress unused parameter warning in hex shorthand

### DIFF
--- a/src/ts-default/Backgrounds/LetterGlitch/LetterGlitch.tsx
+++ b/src/ts-default/Backgrounds/LetterGlitch/LetterGlitch.tsx
@@ -104,7 +104,7 @@ const LetterGlitch = ({
 
   const hexToRgb = (hex: string) => {
     const shorthandRegex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i;
-    hex = hex.replace(shorthandRegex, (m, r, g, b) => {
+    hex = hex.replace(shorthandRegex, (_m, r, g, b) => {
       return r + r + g + g + b + b;
     });
 

--- a/src/ts-tailwind/Backgrounds/LetterGlitch/LetterGlitch.tsx
+++ b/src/ts-tailwind/Backgrounds/LetterGlitch/LetterGlitch.tsx
@@ -104,7 +104,7 @@ const LetterGlitch = ({
 
   const hexToRgb = (hex: string) => {
     const shorthandRegex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i;
-    hex = hex.replace(shorthandRegex, (m, r, g, b) => {
+    hex = hex.replace(shorthandRegex, (_m, r, g, b) => {
       return r + r + g + g + b + b;
     });
 


### PR DESCRIPTION
Renames `m` to `_m` in replace callback to indicate intentional non-use and avoid TS `noUnusedParameters` warning.