### PR TITLE
Fix CardSwap animation by animating on z axis

### DIFF
--- a/src/content/Components/CardSwap/CardSwap.jsx
+++ b/src/content/Components/CardSwap/CardSwap.jsx
@@ -150,11 +150,12 @@ const CardSwap = ({
         undefined,
         "return"
       );
-      tl.set(elFront, { x: backSlot.x, z: backSlot.z }, "return");
       tl.to(
         elFront,
         {
+          x: backSlot.x,
           y: backSlot.y,
+          z: backSlot.z,
           duration: config.durReturn,
           ease: config.ease,
         },


### PR DESCRIPTION
When the lower section of the cards are visible the animation feels snappy. By animating on the z and x axis it fixes that.