### PR TITLE
fix: Add PrismContainer interface for IntersectionObserver

### DIFF
--- a/src/ts-default/Backgrounds/Prism/Prism.tsx
+++ b/src/ts-default/Backgrounds/Prism/Prism.tsx
@@ -401,6 +401,10 @@ const Prism: React.FC<PrismProps> = ({
       }
     };
 
+    interface PrismContainer extends HTMLElement {
+      __prismIO?: IntersectionObserver
+    }
+
     if (suspendWhenOffscreen) {
       const io = new IntersectionObserver(entries => {
         const vis = entries.some(e => e.isIntersecting);
@@ -409,7 +413,7 @@ const Prism: React.FC<PrismProps> = ({
       });
       io.observe(container);
       startRAF();
-      (container as any).__prismIO = io;
+      (container as PrismContainer).__prismIO = io;
     } else {
       startRAF();
     }
@@ -423,9 +427,9 @@ const Prism: React.FC<PrismProps> = ({
         window.removeEventListener('blur', onBlur);
       }
       if (suspendWhenOffscreen) {
-        const io = (container as any).__prismIO as IntersectionObserver | undefined;
+        const io = (container as PrismContainer).__prismIO as IntersectionObserver | undefined;
         if (io) io.disconnect();
-        delete (container as any).__prismIO;
+        delete (container as PrismContainer).__prismIO;
       }
       if (gl.canvas.parentElement === container) container.removeChild(gl.canvas);
     };

--- a/src/ts-tailwind/Backgrounds/Prism/Prism.tsx
+++ b/src/ts-tailwind/Backgrounds/Prism/Prism.tsx
@@ -400,6 +400,10 @@ const Prism: React.FC<PrismProps> = ({
       }
     };
 
+    interface PrismContainer extends HTMLElement {
+      __prismIO?: IntersectionObserver
+    }
+
     if (suspendWhenOffscreen) {
       const io = new IntersectionObserver(entries => {
         const vis = entries.some(e => e.isIntersecting);
@@ -408,7 +412,7 @@ const Prism: React.FC<PrismProps> = ({
       });
       io.observe(container);
       startRAF();
-      (container as any).__prismIO = io;
+      (container as PrismContainer).__prismIO = io;
     } else {
       startRAF();
     }
@@ -422,9 +426,9 @@ const Prism: React.FC<PrismProps> = ({
         window.removeEventListener('blur', onBlur);
       }
       if (suspendWhenOffscreen) {
-        const io = (container as any).__prismIO as IntersectionObserver | undefined;
+        const io = (container as PrismContainer).__prismIO as IntersectionObserver | undefined;
         if (io) io.disconnect();
-        delete (container as any).__prismIO;
+        delete (container as PrismContainer).__prismIO;
       }
       if (gl.canvas.parentElement === container) container.removeChild(gl.canvas);
     };


### PR DESCRIPTION
Introduced a PrismContainer interface to type the __prismIO property on HTMLElement, replacing previous use of 'any' casting. This improves type safety when attaching and removing the IntersectionObserver instance used for offscreen suspension.