### PR TITLE
fix: resolve Dither background scroll flickering issue

### DIFF
--- a/src/tailwind/Backgrounds/Dither/Dither.jsx
+++ b/src/tailwind/Backgrounds/Dither/Dither.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/no-unknown-property */
-import { useRef, useEffect, forwardRef } from 'react';
+import { useRef, useEffect, forwardRef, useState, useCallback } from 'react';
 import { Canvas, useFrame, useThree } from '@react-three/fiber';
 import { EffectComposer, wrapEffect } from '@react-three/postprocessing';
 import { Effect } from 'postprocessing';
@@ -172,11 +172,21 @@ function DitheredWaves({
   pixelSize,
   disableAnimation,
   enableMouseInteraction,
-  mouseRadius
+  mouseRadius,
+  autoPauseOnScroll = true,
+  scrollPauseThreshold = null,
+  resumeOnScrollUp = true
 }) {
   const mesh = useRef(null);
   const mouseRef = useRef(new THREE.Vector2());
   const { viewport, size, gl } = useThree();
+  
+  // Scroll-based animation pausing
+  const [isScrolling, setIsScrolling] = useState(false);
+  const scrollTimeoutRef = useRef(null);
+  const appliedScrollThresholdRef = useRef(null);
+  const permaPausedRef = useRef(false);
+  const frozenTimeRef = useRef(0);
 
   const waveUniformsRef = useRef({
     time: new THREE.Uniform(0),
@@ -201,11 +211,63 @@ function DitheredWaves({
   }, [size, gl]);
 
   const prevColor = useRef([...waveColor]);
+  
+  // Scroll event handler
+  const handleScroll = useCallback(() => {
+    if (!autoPauseOnScroll) return;
+    
+    const y = window.scrollY || window.pageYOffset;
+    const limit = appliedScrollThresholdRef.current || Math.round(window.innerHeight * 1.2);
+    
+    if (!permaPausedRef.current && y > limit) {
+      setIsScrolling(true);
+      if (!resumeOnScrollUp) permaPausedRef.current = true;
+    } else if (resumeOnScrollUp && y <= limit && !permaPausedRef.current) {
+      setIsScrolling(false);
+    }
+    
+    // Clear existing timeout
+    if (scrollTimeoutRef.current) {
+      clearTimeout(scrollTimeoutRef.current);
+    }
+    
+    // Set timeout to resume animation after scroll ends
+    scrollTimeoutRef.current = setTimeout(() => {
+      setIsScrolling(false);
+    }, 150);
+  }, [autoPauseOnScroll, resumeOnScrollUp]);
+
+  // Setup scroll listener
+  useEffect(() => {
+    if (!autoPauseOnScroll) return;
+    
+    if (!appliedScrollThresholdRef.current) {
+      appliedScrollThresholdRef.current = scrollPauseThreshold ?? Math.round(window.innerHeight * 1.2);
+    }
+    
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    handleScroll(); // Initial check
+    
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+      if (scrollTimeoutRef.current) {
+        clearTimeout(scrollTimeoutRef.current);
+      }
+    };
+  }, [autoPauseOnScroll, scrollPauseThreshold, handleScroll]);
+
   useFrame(({ clock }) => {
     const u = waveUniformsRef.current;
 
-    if (!disableAnimation) {
-      u.time.value = clock.getElapsedTime();
+    // Pause animation during scroll to prevent flickering
+    const shouldPause = disableAnimation || (autoPauseOnScroll && isScrolling);
+    
+    if (!shouldPause) {
+      const elapsedTime = clock.getElapsedTime();
+      u.time.value = elapsedTime;
+      frozenTimeRef.current = elapsedTime;
+    } else {
+      u.time.value = frozenTimeRef.current;
     }
 
     if (u.waveSpeed.value !== waveSpeed) u.waveSpeed.value = waveSpeed;
@@ -269,7 +331,10 @@ export default function Dither({
   pixelSize = 2,
   disableAnimation = false,
   enableMouseInteraction = true,
-  mouseRadius = 1
+  mouseRadius = 1,
+  autoPauseOnScroll = true,
+  scrollPauseThreshold = null,
+  resumeOnScrollUp = true
 }) {
   return (
     <Canvas
@@ -288,6 +353,9 @@ export default function Dither({
         disableAnimation={disableAnimation}
         enableMouseInteraction={enableMouseInteraction}
         mouseRadius={mouseRadius}
+        autoPauseOnScroll={autoPauseOnScroll}
+        scrollPauseThreshold={scrollPauseThreshold}
+        resumeOnScrollUp={resumeOnScrollUp}
       />
     </Canvas>
   );

--- a/src/tailwind/Backgrounds/Dither/Dither.jsx
+++ b/src/tailwind/Backgrounds/Dither/Dither.jsx
@@ -172,21 +172,11 @@ function DitheredWaves({
   pixelSize,
   disableAnimation,
   enableMouseInteraction,
-  mouseRadius,
-  autoPauseOnScroll = true,
-  scrollPauseThreshold = null,
-  resumeOnScrollUp = true
+  mouseRadius
 }) {
   const mesh = useRef(null);
   const mouseRef = useRef(new THREE.Vector2());
   const { viewport, size, gl } = useThree();
-  
-  // Scroll-based animation pausing
-  const [isScrolling, setIsScrolling] = useState(false);
-  const scrollTimeoutRef = useRef(null);
-  const appliedScrollThresholdRef = useRef(null);
-  const permaPausedRef = useRef(false);
-  const frozenTimeRef = useRef(0);
 
   const waveUniformsRef = useRef({
     time: new THREE.Uniform(0),
@@ -211,63 +201,11 @@ function DitheredWaves({
   }, [size, gl]);
 
   const prevColor = useRef([...waveColor]);
-  
-  // Scroll event handler
-  const handleScroll = useCallback(() => {
-    if (!autoPauseOnScroll) return;
-    
-    const y = window.scrollY || window.pageYOffset;
-    const limit = appliedScrollThresholdRef.current || Math.round(window.innerHeight * 1.2);
-    
-    if (!permaPausedRef.current && y > limit) {
-      setIsScrolling(true);
-      if (!resumeOnScrollUp) permaPausedRef.current = true;
-    } else if (resumeOnScrollUp && y <= limit && !permaPausedRef.current) {
-      setIsScrolling(false);
-    }
-    
-    // Clear existing timeout
-    if (scrollTimeoutRef.current) {
-      clearTimeout(scrollTimeoutRef.current);
-    }
-    
-    // Set timeout to resume animation after scroll ends
-    scrollTimeoutRef.current = setTimeout(() => {
-      setIsScrolling(false);
-    }, 150);
-  }, [autoPauseOnScroll, resumeOnScrollUp]);
-
-  // Setup scroll listener
-  useEffect(() => {
-    if (!autoPauseOnScroll) return;
-    
-    if (!appliedScrollThresholdRef.current) {
-      appliedScrollThresholdRef.current = scrollPauseThreshold ?? Math.round(window.innerHeight * 1.2);
-    }
-    
-    window.addEventListener('scroll', handleScroll, { passive: true });
-    handleScroll(); // Initial check
-    
-    return () => {
-      window.removeEventListener('scroll', handleScroll);
-      if (scrollTimeoutRef.current) {
-        clearTimeout(scrollTimeoutRef.current);
-      }
-    };
-  }, [autoPauseOnScroll, scrollPauseThreshold, handleScroll]);
-
   useFrame(({ clock }) => {
     const u = waveUniformsRef.current;
 
-    // Pause animation during scroll to prevent flickering
-    const shouldPause = disableAnimation || (autoPauseOnScroll && isScrolling);
-    
-    if (!shouldPause) {
-      const elapsedTime = clock.getElapsedTime();
-      u.time.value = elapsedTime;
-      frozenTimeRef.current = elapsedTime;
-    } else {
-      u.time.value = frozenTimeRef.current;
+    if (!disableAnimation) {
+      u.time.value = clock.getElapsedTime();
     }
 
     if (u.waveSpeed.value !== waveSpeed) u.waveSpeed.value = waveSpeed;
@@ -336,12 +274,65 @@ export default function Dither({
   scrollPauseThreshold = null,
   resumeOnScrollUp = true
 }) {
+  const [isScrolling, setIsScrolling] = useState(false);
+  const scrollTimeoutRef = useRef(null);
+  const appliedScrollThresholdRef = useRef(null);
+  const permaPausedRef = useRef(false);
+
+  // Scroll event handler for Canvas-level pausing
+  const handleScroll = useCallback(() => {
+    if (!autoPauseOnScroll) return;
+    
+    const y = window.scrollY || window.pageYOffset;
+    const limit = appliedScrollThresholdRef.current || Math.round(window.innerHeight * 1.2);
+    
+    if (!permaPausedRef.current && y > limit) {
+      setIsScrolling(true);
+      if (!resumeOnScrollUp) permaPausedRef.current = true;
+    } else if (resumeOnScrollUp && y <= limit && !permaPausedRef.current) {
+      setIsScrolling(false);
+    }
+    
+    // Clear existing timeout
+    if (scrollTimeoutRef.current) {
+      clearTimeout(scrollTimeoutRef.current);
+    }
+    
+    // Set timeout to resume animation after scroll ends
+    scrollTimeoutRef.current = setTimeout(() => {
+      setIsScrolling(false);
+    }, 150);
+  }, [autoPauseOnScroll, resumeOnScrollUp]);
+
+  // Setup scroll listener
+  useEffect(() => {
+    if (!autoPauseOnScroll) return;
+    
+    if (!appliedScrollThresholdRef.current) {
+      appliedScrollThresholdRef.current = scrollPauseThreshold ?? Math.round(window.innerHeight * 1.2);
+    }
+    
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    handleScroll(); // Initial check
+    
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+      if (scrollTimeoutRef.current) {
+        clearTimeout(scrollTimeoutRef.current);
+      }
+    };
+  }, [autoPauseOnScroll, scrollPauseThreshold, handleScroll]);
+
+  // Determine if Canvas should be paused
+  const shouldPauseCanvas = disableAnimation || (autoPauseOnScroll && isScrolling);
+
   return (
     <Canvas
       className="w-full h-full relative"
       camera={{ position: [0, 0, 6] }}
       dpr={window.devicePixelRatio}
       gl={{ antialias: true, preserveDrawingBuffer: true }}
+      frameloop={shouldPauseCanvas ? 'never' : 'always'}
     >
       <DitheredWaves
         waveSpeed={waveSpeed}
@@ -353,9 +344,6 @@ export default function Dither({
         disableAnimation={disableAnimation}
         enableMouseInteraction={enableMouseInteraction}
         mouseRadius={mouseRadius}
-        autoPauseOnScroll={autoPauseOnScroll}
-        scrollPauseThreshold={scrollPauseThreshold}
-        resumeOnScrollUp={resumeOnScrollUp}
       />
     </Canvas>
   );

--- a/src/ts-default/Backgrounds/Dither/Dither.tsx
+++ b/src/ts-default/Backgrounds/Dither/Dither.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/no-unknown-property */
-import { useRef, useEffect, forwardRef } from 'react';
+import { useRef, useEffect, forwardRef, useState, useCallback } from 'react';
 import { Canvas, useFrame, useThree, ThreeEvent } from '@react-three/fiber';
 import { EffectComposer, wrapEffect } from '@react-three/postprocessing';
 import { Effect } from 'postprocessing';
@@ -189,6 +189,9 @@ interface DitheredWavesProps {
   disableAnimation: boolean;
   enableMouseInteraction: boolean;
   mouseRadius: number;
+  autoPauseOnScroll?: boolean;
+  scrollPauseThreshold?: number | null;
+  resumeOnScrollUp?: boolean;
 }
 
 function DitheredWaves({
@@ -200,11 +203,21 @@ function DitheredWaves({
   pixelSize,
   disableAnimation,
   enableMouseInteraction,
-  mouseRadius
+  mouseRadius,
+  autoPauseOnScroll = true,
+  scrollPauseThreshold = null,
+  resumeOnScrollUp = true
 }: DitheredWavesProps) {
   const mesh = useRef<THREE.Mesh>(null);
   const mouseRef = useRef(new THREE.Vector2());
   const { viewport, size, gl } = useThree();
+  
+  // Scroll-based animation pausing
+  const [isScrolling, setIsScrolling] = useState(false);
+  const scrollTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const appliedScrollThresholdRef = useRef<number | null>(null);
+  const permaPausedRef = useRef(false);
+  const frozenTimeRef = useRef(0);
 
   const waveUniformsRef = useRef<WaveUniforms>({
     time: new THREE.Uniform(0),
@@ -229,11 +242,63 @@ function DitheredWaves({
   }, [size, gl]);
 
   const prevColor = useRef([...waveColor]);
+  
+  // Scroll event handler
+  const handleScroll = useCallback(() => {
+    if (!autoPauseOnScroll) return;
+    
+    const y = window.scrollY || window.pageYOffset;
+    const limit = appliedScrollThresholdRef.current || Math.round(window.innerHeight * 1.2);
+    
+    if (!permaPausedRef.current && y > limit) {
+      setIsScrolling(true);
+      if (!resumeOnScrollUp) permaPausedRef.current = true;
+    } else if (resumeOnScrollUp && y <= limit && !permaPausedRef.current) {
+      setIsScrolling(false);
+    }
+    
+    // Clear existing timeout
+    if (scrollTimeoutRef.current) {
+      clearTimeout(scrollTimeoutRef.current);
+    }
+    
+    // Set timeout to resume animation after scroll ends
+    scrollTimeoutRef.current = setTimeout(() => {
+      setIsScrolling(false);
+    }, 150);
+  }, [autoPauseOnScroll, resumeOnScrollUp]);
+
+  // Setup scroll listener
+  useEffect(() => {
+    if (!autoPauseOnScroll) return;
+    
+    if (!appliedScrollThresholdRef.current) {
+      appliedScrollThresholdRef.current = scrollPauseThreshold ?? Math.round(window.innerHeight * 1.2);
+    }
+    
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    handleScroll(); // Initial check
+    
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+      if (scrollTimeoutRef.current) {
+        clearTimeout(scrollTimeoutRef.current);
+      }
+    };
+  }, [autoPauseOnScroll, scrollPauseThreshold, handleScroll]);
+
   useFrame(({ clock }) => {
     const u = waveUniformsRef.current;
 
-    if (!disableAnimation) {
-      u.time.value = clock.getElapsedTime();
+    // Pause animation during scroll to prevent flickering
+    const shouldPause = disableAnimation || (autoPauseOnScroll && isScrolling);
+    
+    if (!shouldPause) {
+      const elapsedTime = clock.getElapsedTime();
+      u.time.value = elapsedTime;
+      frozenTimeRef.current = elapsedTime;
+    } else {
+      u.time.value = frozenTimeRef.current;
     }
 
     if (u.waveSpeed.value !== waveSpeed) u.waveSpeed.value = waveSpeed;
@@ -298,6 +363,9 @@ interface DitherProps {
   disableAnimation?: boolean;
   enableMouseInteraction?: boolean;
   mouseRadius?: number;
+  autoPauseOnScroll?: boolean;
+  scrollPauseThreshold?: number | null;
+  resumeOnScrollUp?: boolean;
 }
 
 export default function Dither({
@@ -309,7 +377,10 @@ export default function Dither({
   pixelSize = 2,
   disableAnimation = false,
   enableMouseInteraction = true,
-  mouseRadius = 1
+  mouseRadius = 1,
+  autoPauseOnScroll = true,
+  scrollPauseThreshold = null,
+  resumeOnScrollUp = true
 }: DitherProps) {
   return (
     <Canvas
@@ -328,6 +399,9 @@ export default function Dither({
         disableAnimation={disableAnimation}
         enableMouseInteraction={enableMouseInteraction}
         mouseRadius={mouseRadius}
+        autoPauseOnScroll={autoPauseOnScroll}
+        scrollPauseThreshold={scrollPauseThreshold}
+        resumeOnScrollUp={resumeOnScrollUp}
       />
     </Canvas>
   );

--- a/src/ts-default/Backgrounds/Dither/Dither.tsx
+++ b/src/ts-default/Backgrounds/Dither/Dither.tsx
@@ -189,9 +189,6 @@ interface DitheredWavesProps {
   disableAnimation: boolean;
   enableMouseInteraction: boolean;
   mouseRadius: number;
-  autoPauseOnScroll?: boolean;
-  scrollPauseThreshold?: number | null;
-  resumeOnScrollUp?: boolean;
 }
 
 function DitheredWaves({
@@ -203,21 +200,11 @@ function DitheredWaves({
   pixelSize,
   disableAnimation,
   enableMouseInteraction,
-  mouseRadius,
-  autoPauseOnScroll = true,
-  scrollPauseThreshold = null,
-  resumeOnScrollUp = true
+  mouseRadius
 }: DitheredWavesProps) {
   const mesh = useRef<THREE.Mesh>(null);
   const mouseRef = useRef(new THREE.Vector2());
   const { viewport, size, gl } = useThree();
-  
-  // Scroll-based animation pausing
-  const [isScrolling, setIsScrolling] = useState(false);
-  const scrollTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-  const appliedScrollThresholdRef = useRef<number | null>(null);
-  const permaPausedRef = useRef(false);
-  const frozenTimeRef = useRef(0);
 
   const waveUniformsRef = useRef<WaveUniforms>({
     time: new THREE.Uniform(0),
@@ -242,63 +229,11 @@ function DitheredWaves({
   }, [size, gl]);
 
   const prevColor = useRef([...waveColor]);
-  
-  // Scroll event handler
-  const handleScroll = useCallback(() => {
-    if (!autoPauseOnScroll) return;
-    
-    const y = window.scrollY || window.pageYOffset;
-    const limit = appliedScrollThresholdRef.current || Math.round(window.innerHeight * 1.2);
-    
-    if (!permaPausedRef.current && y > limit) {
-      setIsScrolling(true);
-      if (!resumeOnScrollUp) permaPausedRef.current = true;
-    } else if (resumeOnScrollUp && y <= limit && !permaPausedRef.current) {
-      setIsScrolling(false);
-    }
-    
-    // Clear existing timeout
-    if (scrollTimeoutRef.current) {
-      clearTimeout(scrollTimeoutRef.current);
-    }
-    
-    // Set timeout to resume animation after scroll ends
-    scrollTimeoutRef.current = setTimeout(() => {
-      setIsScrolling(false);
-    }, 150);
-  }, [autoPauseOnScroll, resumeOnScrollUp]);
-
-  // Setup scroll listener
-  useEffect(() => {
-    if (!autoPauseOnScroll) return;
-    
-    if (!appliedScrollThresholdRef.current) {
-      appliedScrollThresholdRef.current = scrollPauseThreshold ?? Math.round(window.innerHeight * 1.2);
-    }
-    
-    window.addEventListener('scroll', handleScroll, { passive: true });
-    handleScroll(); // Initial check
-    
-    return () => {
-      window.removeEventListener('scroll', handleScroll);
-      if (scrollTimeoutRef.current) {
-        clearTimeout(scrollTimeoutRef.current);
-      }
-    };
-  }, [autoPauseOnScroll, scrollPauseThreshold, handleScroll]);
-
   useFrame(({ clock }) => {
     const u = waveUniformsRef.current;
 
-    // Pause animation during scroll to prevent flickering
-    const shouldPause = disableAnimation || (autoPauseOnScroll && isScrolling);
-    
-    if (!shouldPause) {
-      const elapsedTime = clock.getElapsedTime();
-      u.time.value = elapsedTime;
-      frozenTimeRef.current = elapsedTime;
-    } else {
-      u.time.value = frozenTimeRef.current;
+    if (!disableAnimation) {
+      u.time.value = clock.getElapsedTime();
     }
 
     if (u.waveSpeed.value !== waveSpeed) u.waveSpeed.value = waveSpeed;
@@ -382,12 +317,65 @@ export default function Dither({
   scrollPauseThreshold = null,
   resumeOnScrollUp = true
 }: DitherProps) {
+  const [isScrolling, setIsScrolling] = useState(false);
+  const scrollTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const appliedScrollThresholdRef = useRef<number | null>(null);
+  const permaPausedRef = useRef(false);
+
+  // Scroll event handler for Canvas-level pausing
+  const handleScroll = useCallback(() => {
+    if (!autoPauseOnScroll) return;
+    
+    const y = window.scrollY || window.pageYOffset;
+    const limit = appliedScrollThresholdRef.current || Math.round(window.innerHeight * 1.2);
+    
+    if (!permaPausedRef.current && y > limit) {
+      setIsScrolling(true);
+      if (!resumeOnScrollUp) permaPausedRef.current = true;
+    } else if (resumeOnScrollUp && y <= limit && !permaPausedRef.current) {
+      setIsScrolling(false);
+    }
+    
+    // Clear existing timeout
+    if (scrollTimeoutRef.current) {
+      clearTimeout(scrollTimeoutRef.current);
+    }
+    
+    // Set timeout to resume animation after scroll ends
+    scrollTimeoutRef.current = setTimeout(() => {
+      setIsScrolling(false);
+    }, 150);
+  }, [autoPauseOnScroll, resumeOnScrollUp]);
+
+  // Setup scroll listener
+  useEffect(() => {
+    if (!autoPauseOnScroll) return;
+    
+    if (!appliedScrollThresholdRef.current) {
+      appliedScrollThresholdRef.current = scrollPauseThreshold ?? Math.round(window.innerHeight * 1.2);
+    }
+    
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    handleScroll(); // Initial check
+    
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+      if (scrollTimeoutRef.current) {
+        clearTimeout(scrollTimeoutRef.current);
+      }
+    };
+  }, [autoPauseOnScroll, scrollPauseThreshold, handleScroll]);
+
+  // Determine if Canvas should be paused
+  const shouldPauseCanvas = disableAnimation || (autoPauseOnScroll && isScrolling);
+
   return (
     <Canvas
       className="dither-container"
       camera={{ position: [0, 0, 6] }}
       dpr={window.devicePixelRatio}
       gl={{ antialias: true, preserveDrawingBuffer: true }}
+      frameloop={shouldPauseCanvas ? 'never' : 'always'}
     >
       <DitheredWaves
         waveSpeed={waveSpeed}
@@ -399,9 +387,6 @@ export default function Dither({
         disableAnimation={disableAnimation}
         enableMouseInteraction={enableMouseInteraction}
         mouseRadius={mouseRadius}
-        autoPauseOnScroll={autoPauseOnScroll}
-        scrollPauseThreshold={scrollPauseThreshold}
-        resumeOnScrollUp={resumeOnScrollUp}
       />
     </Canvas>
   );

--- a/src/ts-tailwind/Backgrounds/Dither/Dither.tsx
+++ b/src/ts-tailwind/Backgrounds/Dither/Dither.tsx
@@ -187,9 +187,6 @@ interface DitheredWavesProps {
   disableAnimation: boolean;
   enableMouseInteraction: boolean;
   mouseRadius: number;
-  autoPauseOnScroll?: boolean;
-  scrollPauseThreshold?: number | null;
-  resumeOnScrollUp?: boolean;
 }
 
 function DitheredWaves({
@@ -201,21 +198,11 @@ function DitheredWaves({
   pixelSize,
   disableAnimation,
   enableMouseInteraction,
-  mouseRadius,
-  autoPauseOnScroll = true,
-  scrollPauseThreshold = null,
-  resumeOnScrollUp = true
+  mouseRadius
 }: DitheredWavesProps) {
   const mesh = useRef<THREE.Mesh>(null);
   const mouseRef = useRef(new THREE.Vector2());
   const { viewport, size, gl } = useThree();
-  
-  // Scroll-based animation pausing
-  const [isScrolling, setIsScrolling] = useState(false);
-  const scrollTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-  const appliedScrollThresholdRef = useRef<number | null>(null);
-  const permaPausedRef = useRef(false);
-  const frozenTimeRef = useRef(0);
 
   const waveUniformsRef = useRef<WaveUniforms>({
     time: new THREE.Uniform(0),
@@ -240,63 +227,11 @@ function DitheredWaves({
   }, [size, gl]);
 
   const prevColor = useRef([...waveColor]);
-  
-  // Scroll event handler
-  const handleScroll = useCallback(() => {
-    if (!autoPauseOnScroll) return;
-    
-    const y = window.scrollY || window.pageYOffset;
-    const limit = appliedScrollThresholdRef.current || Math.round(window.innerHeight * 1.2);
-    
-    if (!permaPausedRef.current && y > limit) {
-      setIsScrolling(true);
-      if (!resumeOnScrollUp) permaPausedRef.current = true;
-    } else if (resumeOnScrollUp && y <= limit && !permaPausedRef.current) {
-      setIsScrolling(false);
-    }
-    
-    // Clear existing timeout
-    if (scrollTimeoutRef.current) {
-      clearTimeout(scrollTimeoutRef.current);
-    }
-    
-    // Set timeout to resume animation after scroll ends
-    scrollTimeoutRef.current = setTimeout(() => {
-      setIsScrolling(false);
-    }, 150);
-  }, [autoPauseOnScroll, resumeOnScrollUp]);
-
-  // Setup scroll listener
-  useEffect(() => {
-    if (!autoPauseOnScroll) return;
-    
-    if (!appliedScrollThresholdRef.current) {
-      appliedScrollThresholdRef.current = scrollPauseThreshold ?? Math.round(window.innerHeight * 1.2);
-    }
-    
-    window.addEventListener('scroll', handleScroll, { passive: true });
-    handleScroll(); // Initial check
-    
-    return () => {
-      window.removeEventListener('scroll', handleScroll);
-      if (scrollTimeoutRef.current) {
-        clearTimeout(scrollTimeoutRef.current);
-      }
-    };
-  }, [autoPauseOnScroll, scrollPauseThreshold, handleScroll]);
-
   useFrame(({ clock }) => {
     const u = waveUniformsRef.current;
 
-    // Pause animation during scroll to prevent flickering
-    const shouldPause = disableAnimation || (autoPauseOnScroll && isScrolling);
-    
-    if (!shouldPause) {
-      const elapsedTime = clock.getElapsedTime();
-      u.time.value = elapsedTime;
-      frozenTimeRef.current = elapsedTime;
-    } else {
-      u.time.value = frozenTimeRef.current;
+    if (!disableAnimation) {
+      u.time.value = clock.getElapsedTime();
     }
 
     if (u.waveSpeed.value !== waveSpeed) u.waveSpeed.value = waveSpeed;
@@ -380,12 +315,65 @@ export default function Dither({
   scrollPauseThreshold = null,
   resumeOnScrollUp = true
 }: DitherProps) {
+  const [isScrolling, setIsScrolling] = useState(false);
+  const scrollTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const appliedScrollThresholdRef = useRef<number | null>(null);
+  const permaPausedRef = useRef(false);
+
+  // Scroll event handler for Canvas-level pausing
+  const handleScroll = useCallback(() => {
+    if (!autoPauseOnScroll) return;
+    
+    const y = window.scrollY || window.pageYOffset;
+    const limit = appliedScrollThresholdRef.current || Math.round(window.innerHeight * 1.2);
+    
+    if (!permaPausedRef.current && y > limit) {
+      setIsScrolling(true);
+      if (!resumeOnScrollUp) permaPausedRef.current = true;
+    } else if (resumeOnScrollUp && y <= limit && !permaPausedRef.current) {
+      setIsScrolling(false);
+    }
+    
+    // Clear existing timeout
+    if (scrollTimeoutRef.current) {
+      clearTimeout(scrollTimeoutRef.current);
+    }
+    
+    // Set timeout to resume animation after scroll ends
+    scrollTimeoutRef.current = setTimeout(() => {
+      setIsScrolling(false);
+    }, 150);
+  }, [autoPauseOnScroll, resumeOnScrollUp]);
+
+  // Setup scroll listener
+  useEffect(() => {
+    if (!autoPauseOnScroll) return;
+    
+    if (!appliedScrollThresholdRef.current) {
+      appliedScrollThresholdRef.current = scrollPauseThreshold ?? Math.round(window.innerHeight * 1.2);
+    }
+    
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    handleScroll(); // Initial check
+    
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+      if (scrollTimeoutRef.current) {
+        clearTimeout(scrollTimeoutRef.current);
+      }
+    };
+  }, [autoPauseOnScroll, scrollPauseThreshold, handleScroll]);
+
+  // Determine if Canvas should be paused
+  const shouldPauseCanvas = disableAnimation || (autoPauseOnScroll && isScrolling);
+
   return (
     <Canvas
       className="w-full h-full relative"
       camera={{ position: [0, 0, 6] }}
       dpr={window.devicePixelRatio}
       gl={{ antialias: true, preserveDrawingBuffer: true }}
+      frameloop={shouldPauseCanvas ? 'never' : 'always'}
     >
       <DitheredWaves
         waveSpeed={waveSpeed}
@@ -397,9 +385,6 @@ export default function Dither({
         disableAnimation={disableAnimation}
         enableMouseInteraction={enableMouseInteraction}
         mouseRadius={mouseRadius}
-        autoPauseOnScroll={autoPauseOnScroll}
-        scrollPauseThreshold={scrollPauseThreshold}
-        resumeOnScrollUp={resumeOnScrollUp}
       />
     </Canvas>
   );


### PR DESCRIPTION
- Add scroll-based animation pausing to prevent flickering during scroll
- Implement autoPauseOnScroll, scrollPauseThreshold, and resumeOnScrollUp props
- Freeze animation time during scroll events to maintain visual consistency
- Add scroll event listener with passive option for better performance
- Apply fix to all 4 Dither component variants (JSX, TS+CSS, TS+TW, JS+TW)
- Resolves performance issue where intensive shader calculations conflicted with browser scroll rendering

Fixes: Background flickering during scroll that made the component unusable