### PR TITLE
fix: improve ModelViewer TypeScript type safety

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@types/matter-js": "^0.19.8",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
+    "@types/three": "^0.180.0",
     "@vitejs/plugin-react": "^4.3.4",
     "concurrently": "^9.1.2",
     "eslint": "^8.57.0",


### PR DESCRIPTION
## Summary
Improve TypeScript type safety in ModelViewer component by replacing `any` types with proper type guards and handling material arrays correctly.

## Changes
- Add type guard functions for `isMeshObject` and `isLightObject`
- Replace `any` types with `THREE.Object3D` in traverse callbacks
- Handle both single material and material array cases properly
- Fix TypeScript errors related to material properties
