### PR TITLE
feat: add customization props to PlasmaWaveV2 component

### DIFF
--- a/src/components/landing/PlasmaWave/PlasmaWaveV2.jsx
+++ b/src/components/landing/PlasmaWave/PlasmaWaveV2.jsx
@@ -109,7 +109,17 @@ export default function PlasmaWaveV2({
   autoPauseOnScroll = true,
   scrollPauseThreshold = null,
   resumeOnScrollUp = false,
-  dynamicDpr = false
+  dynamicDpr = false,
+  // style and performance tweaks
+  maxDpr = 1,
+  showOverlay = true,
+  overlayHeight = 200,
+  overlayFrom = '#060010',
+  overlayTo = 'transparent',
+  overlayZIndex = 1,
+  containerClassName,
+  containerStyle = {},
+  pointerEvents = 'none'
 }) {
   const [isMobile, setIsMobile] = useState(false);
   const containerRef = useRef(null);
@@ -141,7 +151,7 @@ export default function PlasmaWaveV2({
 
     const renderer = new Renderer({
       alpha: true,
-      dpr: Math.min(window.devicePixelRatio, 1),
+      dpr: Math.min(window.devicePixelRatio, maxDpr),
       antialias: false,
       depth: false,
       stencil: false,
@@ -236,7 +246,7 @@ export default function PlasmaWaveV2({
       runningRef.current = true;
       startTimeRef.current = performance.now() - program.uniforms.iTime.value * 1000;
       if (dynamicDpr) {
-        const target = Math.min(window.devicePixelRatio, 1);
+        const target = Math.min(window.devicePixelRatio, maxDpr);
         if (renderer.dpr !== target) renderer.dpr = target;
       }
       renderer.render({ scene, camera });
@@ -306,28 +316,32 @@ export default function PlasmaWaveV2({
   return (
     <div
       ref={containerRef}
+      className={containerClassName}
       style={{
         position: 'absolute',
         inset: 0,
         overflow: 'hidden',
         width: '100vw',
         height: '100vh',
-        pointerEvents: 'none',
-        willChange: 'opacity'
+        pointerEvents,
+        willChange: 'opacity',
+        ...containerStyle
       }}
     >
-      <div
-        style={{
-          position: 'absolute',
-          bottom: 0,
-          left: 0,
-          right: 0,
-          height: 200,
-          background: 'linear-gradient(to top, #060010, transparent)',
-          pointerEvents: 'none',
-          zIndex: 1
-        }}
-      />
+      {showOverlay && (
+        <div
+          style={{
+            position: 'absolute',
+            bottom: 0,
+            left: 0,
+            right: 0,
+            height: overlayHeight,
+            background: `linear-gradient(to top, ${overlayFrom}, ${overlayTo})`,
+            pointerEvents: 'none',
+            zIndex: overlayZIndex
+          }}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Overview

This PR introduces small, safe, backwards-compatible enhancements to the PlasmaWaveV2 landing background component. The goal is to give developers and designers tweakable knobs for styling and performance while ensuring default behavior and visuals remain unchanged.

PlasmaWaveV2 is used only on the landing page (src/pages/LandingPage.jsx) and continues to render identically if no new props are passed. No changes to components on the 4 variants.

## What Changed

### Exposed Performance Control

- `maxDpr`: caps device pixel ratio used by the WebGL renderer.
    - Default: `1` (same as before).
    - Helps balance crispness vs. performance/battery drain on high-DPI devices.

- `dynamicDpr`: integrates with `maxDpr` when DPR is updated at runtime.

### Exposed Overlay/Gradient Styling

- `showOverlay`: toggle gradient overlay visibility (default: true).

- `overlayHeight`: control overlay height (default: 200).

- `overlayFrom` / `overlayTo`: customizable gradient colors.
    - Default replicates previous hard-coded fade: #060010 → transparent.

- `overlayZIndex`: adjust stacking order if needed.

### Exposed Container Customization

- `containerClassName`: pass in classes (e.g., `absolute inset-0`).

- `containerStyle`: extend/override inline styles directly.

- `pointerEvents`: default remains `'none'` (click-through), but can now be set to 'auto' for interactivity.

### Benefits

- `Design flexibility`: tweak gradient height, fade colors, or disable overlay entirely.

- `Performance tuning`: adjust DPR for sharper visuals or lighter GPU load.

- `Styling`: make beautiful adjustments to the landing page.

### Testing

Passed local testing with no runtime/syntax errors.

1. Run the dev server and open the landing page.
2. Confirm visuals are unchanged with no new props.
3. Try adjusting props in `LandingPage.jsx` to see immediate effect (e.g., overlayHeight=320, maxDpr=2).
    - E.g. <PlasmaWaveV2 yOffset={0} xOffset={40} rotationDeg={-45} maxDpr={1} showOverlay={true} overlayHeight = {300} overlayFrom={'#0e7efeb1'}/>
    
### Screenshots
<img width="1461" height="708" alt="Screenshot 2025-09-26 165029" src="https://github.com/user-attachments/assets/1b62c6ca-3320-4ff8-9f9b-7c39ed3bf8b2" />

<img width="1463" height="767" alt="Screenshot 2025-09-26 165134" src="https://github.com/user-attachments/assets/c5977b08-a81d-4e23-8688-761b1d15d151" />
