### PR TITLE
Fix: color changing logic for LightRays Background

### DIFF
--- a/src/content/Backgrounds/LightRays/LightRays.jsx
+++ b/src/content/Backgrounds/LightRays/LightRays.jsx
@@ -4,9 +4,29 @@ import './LightRays.css';
 
 const DEFAULT_COLOR = '#ffffff';
 
-const hexToRgb = hex => {
-  const m = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
-  return m ? [parseInt(m[1], 16) / 255, parseInt(m[2], 16) / 255, parseInt(m[3], 16) / 255] : [1, 1, 1];
+const hexToRgb = (hex = '#ffffff') => {
+  // normalize
+  let h = hex.replace('#', '').trim();
+  if (h.length === 3) {
+    h = h.split('').map(ch => ch + ch).join('');
+  }
+  // handle 6 or 8 length
+  if (h.length !== 6 && h.length !== 8) {
+    // fallback white
+    return new Float32Array([1, 1, 1]);
+  }
+
+  const r = parseInt(h.slice(0, 2), 16) / 255;
+  const g = parseInt(h.slice(2, 4), 16) / 255;
+  const b = parseInt(h.slice(4, 6), 16) / 255;
+
+  if (h.length === 8) {
+    const a = parseInt(h.slice(6, 8), 16) / 255;
+    // premultiply RGB by alpha so shader gets correct final color
+    return new Float32Array([r * a, g * a, b * a]);
+  }
+
+  return new Float32Array([r, g, b]);
 };
 
 const getAnchorAndDir = (origin, w, h) => {


### PR DESCRIPTION
The hexToRgb constant expects exactly 6 hex digits and when passed by an 8-digit string, it does not match and the function returns [1,1,1] which is white. Also, some WebGL/ogl code prefers typed arrays for uniform vectors, so it's safer to set uniform values as Float32Array. I replaced your hexToRgb with this function that supports #RGB, #RRGGBB, #RRGGBBAA. I find this minor bug when I'm making my portfolio website and I like to thank you for having this open source codes.