### PR TITLE
Resolving component import errors

### DIFF
--- a/src/constants/code/Components/pillNavCode.js
+++ b/src/constants/code/Components/pillNavCode.js
@@ -25,6 +25,7 @@ import logo from '/path/to/logo.svg';
   pillColor="#ffffff"
   hoveredPillTextColor="#ffffff"
   pillTextColor="#000000"
+  onMobileMenuClick
 />`,
   code,
   css,


### PR DESCRIPTION
I have changed the import component of the PillNav. Now it contains all the properties which are required at the time of importing and using!

It fixes #587

Code-snippet:
<img width="1029" height="926" alt="image" src="https://github.com/user-attachments/assets/267bd7b8-491d-4730-8e80-e24a27d36373" />


File path is: \react-bits\src\constants\code\Components\pillNavCode.js 