### PR TITLE
Fix(TextType): Inherit Text Color When Not Provided

### DIFF
--- a/src/content/TextAnimations/TextType/TextType.jsx
+++ b/src/content/TextAnimations/TextType/TextType.jsx
@@ -42,7 +42,7 @@ const TextType = ({
   }, [variableSpeed, typingSpeed]);
 
   const getCurrentTextColor = () => {
-    if (textColors.length === 0) return undefined;
+    if (textColors.length === 0) return;
     return textColors[currentTextIndex % textColors.length];
   };
 
@@ -156,7 +156,7 @@ const TextType = ({
       className: `text-type ${className}`,
       ...props
     },
-    <span className="text-type__content" style={{ color: getCurrentTextColor() }}>
+    <span className="text-type__content" style={{ color: getCurrentTextColor() || 'inherit' }}>
       {displayedText}
     </span>,
     showCursor && (

--- a/src/tailwind/TextAnimations/TextType/TextType.jsx
+++ b/src/tailwind/TextAnimations/TextType/TextType.jsx
@@ -41,7 +41,7 @@ const TextType = ({
   }, [variableSpeed, typingSpeed]);
 
   const getCurrentTextColor = () => {
-    if (textColors.length === 0) return undefined;
+    if (textColors.length === 0) return;
     return textColors[currentTextIndex % textColors.length];
   };
 
@@ -156,7 +156,7 @@ const TextType = ({
       className: `inline-block whitespace-pre-wrap tracking-tight ${className}`,
       ...props
     },
-    <span className="inline" style={{ color: getCurrentTextColor() }}>
+    <span className="inline" style={{ color: getCurrentTextColor() || 'inherit' }}>
       {displayedText}
     </span>,
     showCursor && (

--- a/src/ts-default/TextAnimations/TextType/TextType.tsx
+++ b/src/ts-default/TextAnimations/TextType/TextType.tsx
@@ -63,7 +63,7 @@ const TextType = ({
   }, [variableSpeed, typingSpeed]);
 
   const getCurrentTextColor = () => {
-    if (textColors.length === 0) return undefined;
+    if (textColors.length === 0) return;
     return textColors[currentTextIndex % textColors.length];
   };
 
@@ -177,7 +177,7 @@ const TextType = ({
       className: `text-type ${className}`,
       ...props
     },
-    <span className="text-type__content" style={{ color: getCurrentTextColor() }}>
+    <span className="text-type__content" style={{ color: getCurrentTextColor() || 'inherit' }}>
       {displayedText}
     </span>,
     showCursor && (

--- a/src/ts-tailwind/TextAnimations/TextType/TextType.tsx
+++ b/src/ts-tailwind/TextAnimations/TextType/TextType.tsx
@@ -62,7 +62,7 @@ const TextType = ({
   }, [variableSpeed, typingSpeed]);
 
   const getCurrentTextColor = () => {
-    if (textColors.length === 0) return undefined;
+    if (textColors.length === 0) return;
     return textColors[currentTextIndex % textColors.length];
   };
 
@@ -176,7 +176,7 @@ const TextType = ({
       className: `inline-block whitespace-pre-wrap tracking-tight ${className}`,
       ...props
     },
-    <span className="inline" style={{ color: getCurrentTextColor() }}>
+    <span className="inline" style={{ color: getCurrentTextColor() || 'inherit' }}>
       {displayedText}
     </span>,
     showCursor && (


### PR DESCRIPTION
## Changes

* Changed `getCurrentTextColor()` to return `undefined` instead of `#ffffff` when no `textColors` are provided

## Why

Previously, the component defaulted to white when `textColors` was empty, preventing color inheritance from parent elements. This gives the component the expected drop-in behaviour.
