### PR TITLE
feat: Improve PixelTransition component accessibility

### DIFF
--- a/src/content/Animations/PixelTransition/PixelTransition.jsx
+++ b/src/content/Animations/PixelTransition/PixelTransition.jsx
@@ -8,9 +8,9 @@ function PixelTransition({
   gridSize = 7,
   pixelColor = 'currentColor',
   animationStepDuration = 0.3,
+  aspectRatio = '100%',
   className = '',
-  style = {},
-  aspectRatio = '100%'
+  style = {}
 }) {
   const containerRef = useRef(null);
   const pixelGridRef = useRef(null);

--- a/src/tailwind/Animations/PixelTransition/PixelTransition.jsx
+++ b/src/tailwind/Animations/PixelTransition/PixelTransition.jsx
@@ -7,9 +7,9 @@ function PixelTransition({
   gridSize = 7,
   pixelColor = 'currentColor',
   animationStepDuration = 0.3,
+  aspectRatio = '100%',
   className = '',
-  style = {},
-  aspectRatio = '100%'
+  style = {}
 }) {
   const containerRef = useRef(null);
   const pixelGridRef = useRef(null);

--- a/src/ts-default/Animations/PixelTransition/PixelTransition.tsx
+++ b/src/ts-default/Animations/PixelTransition/PixelTransition.tsx
@@ -3,8 +3,8 @@ import { gsap } from 'gsap';
 import './PixelTransition.css';
 
 interface PixelTransitionProps {
-  firstContent: React.ReactNode;
-  secondContent: React.ReactNode;
+  firstContent: React.ReactNode | string;
+  secondContent: React.ReactNode | string;
   gridSize?: number;
   pixelColor?: string;
   animationStepDuration?: number;
@@ -19,9 +19,9 @@ const PixelTransition: React.FC<PixelTransitionProps> = ({
   gridSize = 7,
   pixelColor = 'currentColor',
   animationStepDuration = 0.3,
+  aspectRatio = '100%',
   className = '',
-  style = {},
-  aspectRatio = '100%'
+  style = {}
 }) => {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const pixelGridRef = useRef<HTMLDivElement | null>(null);

--- a/src/ts-tailwind/Animations/PixelTransition/PixelTransition.tsx
+++ b/src/ts-tailwind/Animations/PixelTransition/PixelTransition.tsx
@@ -2,8 +2,8 @@ import React, { useRef, useEffect, useState, CSSProperties } from 'react';
 import { gsap } from 'gsap';
 
 interface PixelTransitionProps {
-  firstContent: React.ReactNode;
-  secondContent: React.ReactNode;
+  firstContent: React.ReactNode | string;
+  secondContent: React.ReactNode | string;
   gridSize?: number;
   pixelColor?: string;
   animationStepDuration?: number;
@@ -18,9 +18,9 @@ const PixelTransition: React.FC<PixelTransitionProps> = ({
   gridSize = 7,
   pixelColor = 'currentColor',
   animationStepDuration = 0.3,
+  aspectRatio = '100%',
   className = '',
-  style = {},
-  aspectRatio = '100%'
+  style = {}
 }) => {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const pixelGridRef = useRef<HTMLDivElement | null>(null);


### PR DESCRIPTION
This PR adds the keyboard accessibility enhancements from Issue #622, following up on the `once` prop implementation in #626.
It also includes the minor refactors.



**Accessibility Changes:**
- Triggers transition on `onFocus`/`onBlur` events.
- Enables keyboard focus with `tabIndex={0}`.
- Adds dynamic `aria-hidden` for screen readers.

**Refactoring:**
- Updated the `content` prop types to `React.ReactNode | string` to be consistent with the documentation.
- Aligns prop types and order with the documentation.