### PR TITLE
FIX: Fixed mobile bug by adding proper handling

### DIFF
--- a/src/content/Animations/TargetCursor/TargetCursor.jsx
+++ b/src/content/Animations/TargetCursor/TargetCursor.jsx
@@ -7,6 +7,7 @@ const TargetCursor = ({ targetSelector = '.cursor-target', spinDuration = 2, hid
   const cornersRef = useRef(null);
   const spinTl = useRef(null);
   const dotRef = useRef(null);
+  const lastPosRef = useRef({ x: window.innerWidth / 2, y: window.innerHeight / 2 });
   const constants = useMemo(
     () => ({
       borderWidth: 3,
@@ -18,6 +19,8 @@ const TargetCursor = ({ targetSelector = '.cursor-target', spinDuration = 2, hid
 
   const moveCursor = useCallback((x, y) => {
     if (!cursorRef.current) return;
+    // remember last pointer position (used on mobile when mousemove isn't available)
+    lastPosRef.current = { x, y };
     gsap.to(cursorRef.current, {
       x,
       y,
@@ -73,7 +76,13 @@ const TargetCursor = ({ targetSelector = '.cursor-target', spinDuration = 2, hid
     createSpinTimeline();
 
     const moveHandler = e => moveCursor(e.clientX, e.clientY);
+    const pointerMoveHandler = e => {
+      // pointer events cover touch + mouse
+      if (e.clientX == null || e.clientY == null) return;
+      moveCursor(e.clientX, e.clientY);
+    };
     window.addEventListener('mousemove', moveHandler);
+    window.addEventListener('pointermove', pointerMoveHandler, { passive: true });
 
     const scrollHandler = () => {
       if (!activeTarget || !cursorRef.current) return;
@@ -98,7 +107,6 @@ const TargetCursor = ({ targetSelector = '.cursor-target', spinDuration = 2, hid
     //---------------------------------------------------------------
     // This code for onclick animation
 
-    window.addEventListener('mousemove', moveHandler);
     const mouseDownHandler = () => {
       if (!dotRef.current) return;
       gsap.to(dotRef.current, { scale: 0.7, duration: 0.3 });
@@ -114,6 +122,9 @@ const TargetCursor = ({ targetSelector = '.cursor-target', spinDuration = 2, hid
 
     window.addEventListener('mousedown', mouseDownHandler);
     window.addEventListener('mouseup', mouseUpHandler);
+    // pointer equivalents for touch devices
+    window.addEventListener('pointerdown', mouseDownHandler);
+    window.addEventListener('pointerup', mouseUpHandler);
 
     //----------------------------------------------------------------
     const enterHandler = e => {
@@ -216,7 +227,8 @@ const TargetCursor = ({ targetSelector = '.cursor-target', spinDuration = 2, hid
       };
 
       isAnimatingToTarget = true;
-      updateCorners();
+      // if we don't have a real mouse event (mobile), use last known pointer position
+      updateCorners(lastPosRef.current?.x, lastPosRef.current?.y);
 
       setTimeout(() => {
         isAnimatingToTarget = false;
@@ -299,6 +311,7 @@ const TargetCursor = ({ targetSelector = '.cursor-target', spinDuration = 2, hid
 
     return () => {
       window.removeEventListener('mousemove', moveHandler);
+      window.removeEventListener('pointermove', pointerMoveHandler);
       window.removeEventListener('mouseover', enterHandler);
       window.removeEventListener('scroll', scrollHandler);
 

--- a/src/tailwind/Animations/TargetCursor/TargetCursor.jsx
+++ b/src/tailwind/Animations/TargetCursor/TargetCursor.jsx
@@ -6,6 +6,7 @@ const TargetCursor = ({ targetSelector = '.cursor-target', spinDuration = 2, hid
   const cornersRef = useRef(null);
   const spinTl = useRef(null);
   const dotRef = useRef(null);
+  const lastPosRef = useRef({ x: window.innerWidth / 2, y: window.innerHeight / 2 });
   const constants = useMemo(
     () => ({
       borderWidth: 3,
@@ -17,6 +18,8 @@ const TargetCursor = ({ targetSelector = '.cursor-target', spinDuration = 2, hid
 
   const moveCursor = useCallback((x, y) => {
     if (!cursorRef.current) return;
+    // remember last pointer position (used on mobile when mousemove isn't available)
+    lastPosRef.current = { x, y };
     gsap.to(cursorRef.current, {
       x,
       y,
@@ -72,7 +75,13 @@ const TargetCursor = ({ targetSelector = '.cursor-target', spinDuration = 2, hid
     createSpinTimeline();
 
     const moveHandler = e => moveCursor(e.clientX, e.clientY);
+    const pointerMoveHandler = e => {
+      // pointer events cover touch + mouse
+      if (e.clientX == null || e.clientY == null) return;
+      moveCursor(e.clientX, e.clientY);
+    };
     window.addEventListener('mousemove', moveHandler);
+    window.addEventListener('pointermove', pointerMoveHandler, { passive: true });
 
     const scrollHandler = () => {
       if (!activeTarget || !cursorRef.current) return;
@@ -94,7 +103,6 @@ const TargetCursor = ({ targetSelector = '.cursor-target', spinDuration = 2, hid
 
     window.addEventListener('scroll', scrollHandler, { passive: true });
 
-    window.addEventListener('mousemove', moveHandler);
     const mouseDownHandler = () => {
       if (!dotRef.current) return;
       gsap.to(dotRef.current, { scale: 0.7, duration: 0.3 });
@@ -109,6 +117,9 @@ const TargetCursor = ({ targetSelector = '.cursor-target', spinDuration = 2, hid
 
     window.addEventListener('mousedown', mouseDownHandler);
     window.addEventListener('mouseup', mouseUpHandler);
+    // pointer equivalents for touch devices
+    window.addEventListener('pointerdown', mouseDownHandler);
+    window.addEventListener('pointerup', mouseUpHandler);
 
     const enterHandler = e => {
       const directTarget = e.target;
@@ -209,7 +220,8 @@ const TargetCursor = ({ targetSelector = '.cursor-target', spinDuration = 2, hid
       };
 
       isAnimatingToTarget = true;
-      updateCorners();
+      // if we don't have a real mouse event (mobile), use last known pointer position
+      updateCorners(lastPosRef.current?.x, lastPosRef.current?.y);
 
       setTimeout(() => {
         isAnimatingToTarget = false;
@@ -256,7 +268,7 @@ const TargetCursor = ({ targetSelector = '.cursor-target', spinDuration = 2, hid
           });
         }
 
-        resumeTimeout = setTimeout(() => {
+       resumeTimeout = setTimeout(() => {
           if (!activeTarget && cursorRef.current && spinTl.current) {
             const currentRotation = gsap.getProperty(cursorRef.current, 'rotation');
             const normalizedRotation = currentRotation % 360;
@@ -277,7 +289,7 @@ const TargetCursor = ({ targetSelector = '.cursor-target', spinDuration = 2, hid
           }
           resumeTimeout = null;
         }, 50);
-
+        
         cleanupTarget(target);
       };
 
@@ -292,8 +304,13 @@ const TargetCursor = ({ targetSelector = '.cursor-target', spinDuration = 2, hid
 
     return () => {
       window.removeEventListener('mousemove', moveHandler);
+      window.removeEventListener('pointermove', pointerMoveHandler);
       window.removeEventListener('mouseover', enterHandler);
       window.removeEventListener('scroll', scrollHandler);
+      window.removeEventListener('mousedown', mouseDownHandler);
+      window.removeEventListener('mouseup', mouseUpHandler);
+      window.removeEventListener('pointerdown', mouseDownHandler);
+      window.removeEventListener('pointerup', mouseUpHandler);
 
       if (activeTarget) {
         cleanupTarget(activeTarget);

--- a/src/ts-default/Animations/TargetCursor/TargetCursor.tsx
+++ b/src/ts-default/Animations/TargetCursor/TargetCursor.tsx
@@ -17,6 +17,7 @@ const TargetCursor: React.FC<TargetCursorProps> = ({
   const cornersRef = useRef<NodeListOf<HTMLDivElement>>(null);
   const spinTl = useRef<gsap.core.Timeline>(null);
   const dotRef = useRef<HTMLDivElement>(null);
+  const lastPosRef = useRef<{ x: number; y: number }>({ x: window.innerWidth / 2, y: window.innerHeight / 2 });
   const constants = useMemo(
     () => ({
       borderWidth: 3,
@@ -28,6 +29,8 @@ const TargetCursor: React.FC<TargetCursorProps> = ({
 
   const moveCursor = useCallback((x: number, y: number) => {
     if (!cursorRef.current) return;
+    // remember last pointer position (used on mobile when mousemove isn't available)
+    lastPosRef.current = { x, y };
     gsap.to(cursorRef.current, {
       x,
       y,
@@ -83,7 +86,12 @@ const TargetCursor: React.FC<TargetCursorProps> = ({
     createSpinTimeline();
 
     const moveHandler = (e: MouseEvent) => moveCursor(e.clientX, e.clientY);
+    const pointerMoveHandler = (e: PointerEvent) => {
+      if (e.clientX == null || e.clientY == null) return;
+      moveCursor(e.clientX, e.clientY);
+    };
     window.addEventListener('mousemove', moveHandler);
+    window.addEventListener('pointermove', pointerMoveHandler, { passive: true });
 
     const scrollHandler = () => {
       if (!activeTarget || !cursorRef.current) return;
@@ -120,6 +128,9 @@ const TargetCursor: React.FC<TargetCursorProps> = ({
 
     window.addEventListener('mousedown', mouseDownHandler);
     window.addEventListener('mouseup', mouseUpHandler);
+    // pointer equivalents for touch devices
+    window.addEventListener('pointerdown', mouseDownHandler);
+    window.addEventListener('pointerup', mouseUpHandler);
 
     const enterHandler = (e: MouseEvent) => {
       const directTarget = e.target as Element;
@@ -220,7 +231,8 @@ const TargetCursor: React.FC<TargetCursorProps> = ({
       };
 
       isAnimatingToTarget = true;
-      updateCorners();
+      // if we don't have a real mouse event (mobile), use last known pointer position
+      updateCorners(lastPosRef.current?.x, lastPosRef.current?.y);
 
       setTimeout(() => {
         isAnimatingToTarget = false;
@@ -303,8 +315,13 @@ const TargetCursor: React.FC<TargetCursorProps> = ({
 
     return () => {
       window.removeEventListener('mousemove', moveHandler);
+      window.removeEventListener('pointermove', pointerMoveHandler);
       window.removeEventListener('mouseover', enterHandler);
       window.removeEventListener('scroll', scrollHandler);
+      window.removeEventListener('mousedown', mouseDownHandler);
+      window.removeEventListener('mouseup', mouseUpHandler);
+      window.removeEventListener('pointerdown', mouseDownHandler);
+      window.removeEventListener('pointerup', mouseUpHandler);
 
       if (activeTarget) {
         cleanupTarget(activeTarget);

--- a/src/ts-tailwind/Animations/TargetCursor/TargetCursor.tsx
+++ b/src/ts-tailwind/Animations/TargetCursor/TargetCursor.tsx
@@ -16,6 +16,7 @@ const TargetCursor: React.FC<TargetCursorProps> = ({
   const cornersRef = useRef<NodeListOf<HTMLDivElement>>(null);
   const spinTl = useRef<gsap.core.Timeline>(null);
   const dotRef = useRef<HTMLDivElement>(null);
+  const lastPosRef = useRef<{ x: number; y: number }>({ x: window.innerWidth / 2, y: window.innerHeight / 2 });
   const constants = useMemo(
     () => ({
       borderWidth: 3,
@@ -27,6 +28,8 @@ const TargetCursor: React.FC<TargetCursorProps> = ({
 
   const moveCursor = useCallback((x: number, y: number) => {
     if (!cursorRef.current) return;
+    // remember last pointer position (used on mobile when mousemove isn't available)
+    lastPosRef.current = { x, y };
     gsap.to(cursorRef.current, {
       x,
       y,
@@ -82,7 +85,13 @@ const TargetCursor: React.FC<TargetCursorProps> = ({
     createSpinTimeline();
 
     const moveHandler = (e: MouseEvent) => moveCursor(e.clientX, e.clientY);
+    const pointerMoveHandler = (e: PointerEvent) => {
+      // pointer events cover touch + mouse
+      if (e.clientX == null || e.clientY == null) return;
+      moveCursor(e.clientX, e.clientY);
+    };
     window.addEventListener('mousemove', moveHandler);
+    window.addEventListener('pointermove', pointerMoveHandler, { passive: true });
 
     const scrollHandler = () => {
       if (!activeTarget || !cursorRef.current) return;
@@ -119,6 +128,9 @@ const TargetCursor: React.FC<TargetCursorProps> = ({
 
     window.addEventListener('mousedown', mouseDownHandler);
     window.addEventListener('mouseup', mouseUpHandler);
+    // pointer equivalents for touch devices
+    window.addEventListener('pointerdown', mouseDownHandler);
+    window.addEventListener('pointerup', mouseUpHandler);
 
     const enterHandler = (e: MouseEvent) => {
       const directTarget = e.target as Element;
@@ -219,7 +231,8 @@ const TargetCursor: React.FC<TargetCursorProps> = ({
       };
 
       isAnimatingToTarget = true;
-      updateCorners();
+      // if we don't have a real mouse event (mobile), use last known pointer position
+      updateCorners(lastPosRef.current?.x, lastPosRef.current?.y);
 
       setTimeout(() => {
         isAnimatingToTarget = false;
@@ -302,8 +315,13 @@ const TargetCursor: React.FC<TargetCursorProps> = ({
 
     return () => {
       window.removeEventListener('mousemove', moveHandler);
+      window.removeEventListener('pointermove', pointerMoveHandler);
       window.removeEventListener('mouseover', enterHandler);
       window.removeEventListener('scroll', scrollHandler);
+      window.removeEventListener('mousedown', mouseDownHandler);
+      window.removeEventListener('mouseup', mouseUpHandler);
+      window.removeEventListener('pointerdown', mouseDownHandler);
+      window.removeEventListener('pointerup', mouseUpHandler);
 
       if (activeTarget) {
         cleanupTarget(activeTarget);


### PR DESCRIPTION
This PR fixes issue #642

Problem: on touch/mobile, clicking a button caused the TargetCursor to snap to an incorrect place.

![react-bits-bug-report_1](https://github.com/user-attachments/assets/b72fa31f-0388-4249-a3ce-c7890367b674)
<img width="939" height="730" alt="react-bits-bug-report_2" src="https://github.com/user-attachments/assets/f6397f41-4459-4a97-a01c-518ce6fabbfe" />

Root cause: mobile devices don’t reliably emit mousemove events. 

What I changed (applied to all 4 variants):
- Added lastPosRef initialized to window center.
- Updated moveCursor to store lastPosRef.current = { x, y } whenever the cursor moves.
- Added a pointermove handler registered on window that calls moveCursor(e.clientX, e.clientY) so touches update the stored position.
- Added pointerdown/pointerup equivalents for mousedown/mouseup so touch press/release animations run.
- When entering a target, call updateCorners(lastPosRef.current.x, lastPosRef.current.y) if no mouse event is present (fallback to stored pos).
- Remove pointer listeners (pointermove/pointerdown/pointerup) in the effect cleanup.

Why this fixes the bug:
Touch devices fire pointer events but not mousemove, so the code now listens to pointermove to keep lastPosRef updated for touch moves and taps. When a target is entered without a mouse event (for example on tap), updateCorners is given the stored lastPosRef coordinates instead of undefined or a stale value. Pointerdown/pointerup handlers were added so the click-style press animation runs on touch devices as well.

Outcome:
<img width="710" height="492" alt="react-bist-bug-report-fix_2" src="https://github.com/user-attachments/assets/1d3ea88c-d785-4565-b500-15ba2d2e6a3d" />
![react-bist-bug-report-fix_1](https://github.com/user-attachments/assets/f3595b8b-d249-4430-99c3-d406e9aee0fb)
