### PR TITLE
Improved documentation for ASCIIText component usage.

### DIFF
--- a/src/constants/code/TextAnimations/asciiTextCode.js
+++ b/src/constants/code/TextAnimations/asciiTextCode.js
@@ -6,14 +6,18 @@ import tsTailwind from '@ts-tailwind/TextAnimations/ASCIIText/ASCIIText.tsx?raw'
 export const asciiText = {
   dependencies: `three`,
   usage: `// Component ported and enhanced from https://codepen.io/JuanFuentes/pen/eYEeoyE
-  
+
+// NOTE: The component uses position: absolute and width/height: 100%, which requires a parent container with explicit dimensions.
+
 import ASCIIText from './ASCIIText';
 
-<ASCIIText
-  text='hello_world'
-  enableWaves={true}
-  asciiFontSize={8}
-/>`,
+<div className="relative w-full h-[500px]">
+  <ASCIIText
+    text='hello_world'
+    enableWaves={true}
+    asciiFontSize={8}
+  />
+</div>`,
   code,
   tailwind,
   tsCode,


### PR DESCRIPTION
The component uses position: absolute and width/height: 100%, which requires a parent container with explicit dimensions.
I've updated the usage documentation.

```
<div className="min-h-screen flex items-center justify-center px-6 pt-32 pb-64">
    <div className="flex flex-col items-center text-center max-w-4xl w-full">
        <div className="relative w-full h-[500px]"> -- HERE
            <ASCIIText
                text='404'
                enableWaves={true}
                asciiFontSize={10}
            />
        </div>
        <p className="text-xl text-gray-400 mb-8">Oops! The page you are looking for does not exist.</p>
        <a 
            href="/"
            className="self-center flex items-center gap-2 text-gray-300 transition-colors hover:text-white cursor-target mb-4"
        >
            <ArrowLeft className="h-5 w-5" />
            Back to Home
        </a>
    </div>
</div>
```

<img width="1899" height="1006" alt="image" src="https://github.com/user-attachments/assets/c3046010-7aa8-4d1e-8902-63f9c9f72d12" />

<img width="1886" height="1011" alt="image" src="https://github.com/user-attachments/assets/1e2a30c6-f2b1-4be5-8529-6ffe9693d6ac" />

