### PR TITLE
fix: remove an extra var not needed just for formality

### DIFF
--- a/src/ts-default/Backgrounds/GridScan/GridScan.tsx
+++ b/src/ts-default/Backgrounds/GridScan/GridScan.tsx
@@ -415,7 +415,7 @@ export const GridScan: React.FC<GridScanProps> = ({
         (DeviceOrientationEvent as any).requestPermission
       ) {
         try {
-          const res = await (DeviceOrientationEvent as any).requestPermission();
+          await (DeviceOrientationEvent as any).requestPermission();
         } catch {}
       }
     };

--- a/src/ts-tailwind/Backgrounds/GridScan/GridScan.tsx
+++ b/src/ts-tailwind/Backgrounds/GridScan/GridScan.tsx
@@ -414,7 +414,7 @@ export const GridScan: React.FC<GridScanProps> = ({
         (DeviceOrientationEvent as any).requestPermission
       ) {
         try {
-          const res = await (DeviceOrientationEvent as any).requestPermission();
+          await (DeviceOrientationEvent as any).requestPermission();
         } catch {}
       }
     };


### PR DESCRIPTION
fix: #665 

hey @DavidHDev 

remove that extra variable from ts-default and ts-tailwind for grid scan

<img width="953" height="568" alt="image" src="https://github.com/user-attachments/assets/80f1b7cc-52d7-4204-8111-1062d6427b7b" />

sorry for tagging multiple people on bug.