### PR TITLE
fix: Correct GridMotion 'items' prop TypeScript definition

### DIFF
--- a/src/ts-default/Backgrounds/GridMotion/GridMotion.tsx
+++ b/src/ts-default/Backgrounds/GridMotion/GridMotion.tsx
@@ -1,9 +1,9 @@
-import React, { useEffect, useRef, FC } from 'react';
+import React, { useEffect, useRef, FC, ReactNode} from 'react';
 import { gsap } from 'gsap';
 import './GridMotion.css';
 
 interface GridMotionProps {
-  items?: string[];
+  items?: (string | ReactNode)[];
   gradientColor?: string;
 }
 

--- a/src/ts-tailwind/Backgrounds/GridMotion/GridMotion.tsx
+++ b/src/ts-tailwind/Backgrounds/GridMotion/GridMotion.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useRef, FC } from 'react';
+import { useEffect, useRef, FC, ReactNode } from 'react';
 import { gsap } from 'gsap';
 
 interface GridMotionProps {
-  items?: string[];
+  items?: (string | ReactNode)[];
   gradientColor?: string;
 }
 


### PR DESCRIPTION
Fixes #688

corrects the TypeScript definition for the \`GridMotion\` component's \`items\` prop.

The previous definition restricted input to \`string[]\`, incorrectly causing type errors for developers wanting to pass React elements (\`string \| ReactNode\`), even though the component's underlying JSX rendering logic supports this content.

Chnages made to these files:
* \`src/ts-default/Backgrounds/GridMotion/GridMotion.tsx\`
* \`src/ts-tailwind/Backgrounds/GridMotion/GridMotion.tsx\`
* 
The JavaScript variants were confirmed to require no changes.