### PR TITLE
Fix: Removed the delay API from TextCursor in documents, websites, and demos.

### DIFF
--- a/src/constants/code/TextAnimations/textCursorCode.js
+++ b/src/constants/code/TextAnimations/textCursorCode.js
@@ -10,7 +10,6 @@ export const textCursor = {
 
 <TextCursor
   text="Hello!"
-  delay={0.01}
   spacing={80}
   followMouseDirection={true}
   randomFloat={true}

--- a/src/content/TextAnimations/TextCursor/TextCursor.jsx
+++ b/src/content/TextAnimations/TextCursor/TextCursor.jsx
@@ -4,7 +4,6 @@ import './TextCursor.css';
 
 const TextCursor = ({
   text = '⚛️',
-  delay = 0.01,
   spacing = 100,
   followMouseDirection = true,
   randomFloat = true,

--- a/src/demo/TextAnimations/TextCursorDemo.jsx
+++ b/src/demo/TextAnimations/TextCursorDemo.jsx
@@ -29,12 +29,6 @@ const TextCursorDemo = () => {
       description: 'The text string to display as the trail.'
     },
     {
-      name: 'delay',
-      type: 'number',
-      default: '0.01',
-      description: 'The entry stagger delay in seconds for the fade-out animation.'
-    },
-    {
       name: 'spacing',
       type: 'number',
       default: '100',

--- a/src/tailwind/TextAnimations/TextCursor/TextCursor.jsx
+++ b/src/tailwind/TextAnimations/TextCursor/TextCursor.jsx
@@ -3,7 +3,6 @@ import { motion, AnimatePresence } from 'motion/react';
 
 const TextCursor = ({
   text = '⚛️',
-  delay = 0.01,
   spacing = 100,
   followMouseDirection = true,
   randomFloat = true,

--- a/src/ts-default/TextAnimations/TextCursor/TextCursor.tsx
+++ b/src/ts-default/TextAnimations/TextCursor/TextCursor.tsx
@@ -4,7 +4,6 @@ import './TextCursor.css';
 
 interface TextCursorProps {
   text: string;
-  delay?: number;
   spacing?: number;
   followMouseDirection?: boolean;
   randomFloat?: boolean;
@@ -25,7 +24,6 @@ interface TrailItem {
 
 const TextCursor: React.FC<TextCursorProps> = ({
   text = '⚛️',
-  delay = 0.01,
   spacing = 100,
   followMouseDirection = true,
   randomFloat = true,

--- a/src/ts-tailwind/TextAnimations/TextCursor/TextCursor.tsx
+++ b/src/ts-tailwind/TextAnimations/TextCursor/TextCursor.tsx
@@ -3,7 +3,6 @@ import { motion, AnimatePresence } from 'motion/react';
 
 interface TextCursorProps {
   text: string;
-  delay?: number;
   spacing?: number;
   followMouseDirection?: boolean;
   randomFloat?: boolean;
@@ -24,7 +23,6 @@ interface TrailItem {
 
 const TextCursor: React.FC<TextCursorProps> = ({
   text = '⚛️',
-  delay = 0.01,
   spacing = 100,
   followMouseDirection = true,
   randomFloat = true,


### PR DESCRIPTION
The delay api has been removed from the documentation, demo website, and code examples.