### PR TITLE
Refactor AnimatedContent: custom scroller support, safer cleanup & exit animations

### DIFF
--- a/src/content/Animations/AnimatedContent/AnimatedContent.jsx
+++ b/src/content/Animations/AnimatedContent/AnimatedContent.jsx
@@ -21,7 +21,9 @@ const AnimatedContent = ({
   disappearDuration = 0.5,
   disappearEase = 'power3.in',
   onComplete,
-  onDisappearanceComplete
+  onDisappearanceComplete,
+  className = '',
+  ...props
 }) => {
   const ref = useRef(null);
 
@@ -93,7 +95,16 @@ const AnimatedContent = ({
     disappearEase, onComplete, onDisappearanceComplete
   ]);
 
-  return <div ref={ref} style={{ visibility: 'hidden' }}>{children}</div>;
+  return (
+    <div 
+        ref={ref} 
+        className={className}
+        style={{ visibility: 'hidden' }} 
+        {...props}
+    >
+        {children}
+    </div>
+  );
 };
 
 export default AnimatedContent;

--- a/src/ts-tailwind/Animations/AnimatedContent/AnimatedContent.tsx
+++ b/src/ts-tailwind/Animations/AnimatedContent/AnimatedContent.tsx
@@ -1,26 +1,32 @@
-import React, { useRef, useEffect, ReactNode } from 'react';
+import React, { useRef, useEffect } from 'react';
 import { gsap } from 'gsap';
 import { ScrollTrigger } from 'gsap/ScrollTrigger';
 
 gsap.registerPlugin(ScrollTrigger);
 
-interface AnimatedContentProps {
-  children: ReactNode;
+interface AnimatedContentProps extends React.HTMLAttributes<HTMLDivElement> {
+  children: React.ReactNode;
+  container?: Element | string | null;
   distance?: number;
   direction?: 'vertical' | 'horizontal';
   reverse?: boolean;
   duration?: number;
-  ease?: string | ((progress: number) => number);
+  ease?: string;
   initialOpacity?: number;
   animateOpacity?: boolean;
   scale?: number;
   threshold?: number;
   delay?: number;
+  disappearAfter?: number;
+  disappearDuration?: number;
+  disappearEase?: string;
   onComplete?: () => void;
+  onDisappearanceComplete?: () => void;
 }
 
 const AnimatedContent: React.FC<AnimatedContentProps> = ({
   children,
+  container,
   distance = 100,
   direction = 'vertical',
   reverse = false,
@@ -31,13 +37,26 @@ const AnimatedContent: React.FC<AnimatedContentProps> = ({
   scale = 1,
   threshold = 0.1,
   delay = 0,
-  onComplete
+  disappearAfter = 0,
+  disappearDuration = 0.5,
+  disappearEase = 'power3.in',
+  onComplete,
+  onDisappearanceComplete,
+  className = '',
+  ...props
 }) => {
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const el = ref.current;
     if (!el) return;
+
+    let scrollerTarget: Element | string | null = 
+      container || document.getElementById('snap-main-container') || null;
+    
+    if (typeof scrollerTarget === 'string') {
+        scrollerTarget = document.querySelector(scrollerTarget);
+    }
 
     const axis = direction === 'horizontal' ? 'x' : 'y';
     const offset = reverse ? -distance : distance;
@@ -46,44 +65,66 @@ const AnimatedContent: React.FC<AnimatedContentProps> = ({
     gsap.set(el, {
       [axis]: offset,
       scale,
-      opacity: animateOpacity ? initialOpacity : 1
+      opacity: animateOpacity ? initialOpacity : 1,
+      visibility: 'visible'
     });
 
-    gsap.to(el, {
+    const tl = gsap.timeline({
+      paused: true,
+      delay,
+      onComplete: () => {
+        if (onComplete) onComplete();
+        if (disappearAfter > 0) {
+          gsap.to(el, {
+            [axis]: reverse ? distance : -distance,
+            scale: 0.8,
+            opacity: animateOpacity ? initialOpacity : 0,
+            delay: disappearAfter,
+            duration: disappearDuration,
+            ease: disappearEase,
+            onComplete: () => onDisappearanceComplete?.()
+          });
+        }
+      }
+    });
+
+    tl.to(el, {
       [axis]: 0,
       scale: 1,
       opacity: 1,
       duration,
-      ease,
-      delay,
-      onComplete,
-      scrollTrigger: {
-        trigger: el,
-        start: `top ${startPct}%`,
-        toggleActions: 'play none none none',
-        once: true
-      }
+      ease
+    });
+
+    const st = ScrollTrigger.create({
+      trigger: el,
+      scroller: scrollerTarget || window,
+      start: `top ${startPct}%`,
+      once: true,
+      onEnter: () => tl.play()
     });
 
     return () => {
-      ScrollTrigger.getAll().forEach(t => t.kill());
-      gsap.killTweensOf(el);
+      st.kill();
+      tl.kill();
     };
   }, [
-    distance,
-    direction,
-    reverse,
-    duration,
-    ease,
-    initialOpacity,
-    animateOpacity,
-    scale,
-    threshold,
-    delay,
-    onComplete
+    container,
+    distance, direction, reverse, duration, ease, 
+    initialOpacity, animateOpacity, scale, threshold, 
+    delay, disappearAfter, disappearDuration, 
+    disappearEase, onComplete, onDisappearanceComplete
   ]);
 
-  return <div ref={ref}>{children}</div>;
+  return (
+    <div 
+        ref={ref} 
+        className={`invisible ${className}`} 
+        {...props}
+    >
+        {children}
+    </div>
+  );
 };
 
 export default AnimatedContent;


### PR DESCRIPTION
Since I use AnimatedContent in my projects, I have been modifying the component to suit my needs as I use it. For this reason, I decided to make this pull request, as I believe that enough has been fixed and added that beginners would really need

### KEY CHANGES
1. Safe Cleanup
**Before:** The component used `ScrollTrigger.getAll().forEach(t => t.kill())` on unmount. This killed ALL scroll triggers on the page, breaking animations in other components
**After:** Now correctly stores references to the specific timeline and trigger instance, killing only its own processes

2. Custom Scroller Support
**Added logic to detect specific scroll containers** (via container prop or snap-main-container id)
Essential for layouts using overflow: scroll, CSS Scroll Snap, or third-party scroll libraries where the window is not the scroller

3. Exit Animations
**Introduced disappearAfter, disappearDuration, and disappearEase props.** Elements can now animate out automatically after the entry animation completes

4. Technical
**Switched** from `gsap.to` to `gsap.timeline` for better control over animation sequencing (Entry -> Delay -> Exit).

### Testing
1. Verify that animations still work in the main window flow
2. Test inside a nested scroll container (pass the container ref)
3. Navigate away from the page and back to ensure other animations are not broken (cleanup check)
4. Test the disappearAfter={2} prop to see the exit animation