### PR TITLE
fix: correct working of custom fonts "font-<custom>" usage in tailwindcss className prop in Shuffle Component.

### DIFF
--- a/src/tailwind/TextAnimations/Shuffle/Shuffle.jsx
+++ b/src/tailwind/TextAnimations/Shuffle/Shuffle.jsx
@@ -51,12 +51,26 @@ const Shuffle = ({
   useGSAP(
     () => {
       if (!ref.current || !text || !fontsLoaded) return;
-      if (respectReducedMotion && window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+
+      if (
+        respectReducedMotion &&
+        window.matchMedia &&
+        window.matchMedia('(prefers-reduced-motion: reduce)').matches
+      ) {
         onShuffleComplete?.();
         return;
       }
 
       const el = ref.current;
+
+      let computedFont = '';
+      const userHasFont =
+        (style && style.fontFamily) || (className && /font[-[]/i.test(className));
+      if (userHasFont) {
+        computedFont = style.fontFamily || getComputedStyle(el).fontFamily || '';
+      } else {
+        computedFont = `'Press Start 2P', sans-serif`;
+      }
 
       const startPct = (1 - threshold) * 100;
       const mm = /^(-?\d+(?:\.\d+)?)(px|em|rem|%)?$/.exec(rootMargin || '');
@@ -78,7 +92,7 @@ const Shuffle = ({
           tlRef.current = null;
         }
         if (wrappersRef.current.length) {
-          wrappersRef.current.forEach(wrap => {
+          wrappersRef.current.forEach((wrap) => {
             const inner = wrap.firstElementChild;
             const orig = inner?.querySelector('[data-orig="1"]');
             if (orig && wrap.parentNode) wrap.parentNode.replaceChild(orig, wrap);
@@ -103,16 +117,16 @@ const Shuffle = ({
           wordsClass: 'shuffle-word',
           linesClass: 'shuffle-line',
           smartWrap: true,
-          reduceWhiteSpace: false
+          reduceWhiteSpace: false,
         });
 
         const chars = splitRef.current.chars || [];
         wrappersRef.current = [];
 
         const rolls = Math.max(1, Math.floor(shuffleTimes));
-        const rand = set => set.charAt(Math.floor(Math.random() * set.length)) || '';
+        const rand = (set) => set.charAt(Math.floor(Math.random() * set.length)) || '';
 
-        chars.forEach(ch => {
+        chars.forEach((ch) => {
           const parent = ch.parentElement;
           if (!parent) return;
 
@@ -124,25 +138,26 @@ const Shuffle = ({
           Object.assign(wrap.style, { width: w + 'px' });
 
           const inner = document.createElement('span');
-          inner.className = 'inline-block whitespace-nowrap will-change-transform origin-left transform-gpu';
+          inner.className =
+            'inline-block whitespace-nowrap will-change-transform origin-left transform-gpu';
 
           parent.insertBefore(wrap, ch);
           wrap.appendChild(inner);
 
           const firstOrig = ch.cloneNode(true);
           firstOrig.className = 'inline-block text-left';
-          Object.assign(firstOrig.style, { width: w + 'px' });
+          Object.assign(firstOrig.style, { width: w + 'px', fontFamily: computedFont });
 
           ch.setAttribute('data-orig', '1');
           ch.className = 'inline-block text-left';
-          Object.assign(ch.style, { width: w + 'px' });
+          Object.assign(ch.style, { width: w + 'px', fontFamily: computedFont });
 
           inner.appendChild(firstOrig);
           for (let k = 0; k < rolls; k++) {
             const c = ch.cloneNode(true);
             if (scrambleCharset) c.textContent = rand(scrambleCharset);
             c.className = 'inline-block text-left';
-            Object.assign(c.style, { width: w + 'px' });
+            Object.assign(c.style, { width: w + 'px', fontFamily: computedFont });
             inner.appendChild(c);
           }
           inner.appendChild(ch);
@@ -161,7 +176,6 @@ const Shuffle = ({
 
           gsap.set(inner, { x: startX, force3D: true });
           if (colorFrom) inner.style.color = colorFrom;
-
           inner.setAttribute('data-final-x', String(finalX));
           inner.setAttribute('data-start-x', String(startX));
 
@@ -169,22 +183,24 @@ const Shuffle = ({
         });
       };
 
-      const inners = () => wrappersRef.current.map(w => w.firstElementChild);
+      const inners = () => wrappersRef.current.map((w) => w.firstElementChild);
 
       const randomizeScrambles = () => {
         if (!scrambleCharset) return;
-        wrappersRef.current.forEach(w => {
+        wrappersRef.current.forEach((w) => {
           const strip = w.firstElementChild;
           if (!strip) return;
           const kids = Array.from(strip.children);
           for (let i = 1; i < kids.length - 1; i++) {
-            kids[i].textContent = scrambleCharset.charAt(Math.floor(Math.random() * scrambleCharset.length));
+            kids[i].textContent = scrambleCharset.charAt(
+              Math.floor(Math.random() * scrambleCharset.length)
+            );
           }
         });
       };
 
       const cleanupToStill = () => {
-        wrappersRef.current.forEach(w => {
+        wrappersRef.current.forEach((w) => {
           const strip = w.firstElementChild;
           if (!strip) return;
           const real = strip.querySelector('[data-orig="1"]');
@@ -218,7 +234,7 @@ const Shuffle = ({
               onShuffleComplete?.();
               armHover();
             }
-          }
+          },
         });
 
         const addTween = (targets, at) => {
@@ -229,7 +245,7 @@ const Shuffle = ({
               duration,
               ease,
               force3D: true,
-              stagger: animationMode === 'evenodd' ? stagger : 0
+              stagger: animationMode === 'evenodd' ? stagger : 0,
             },
             at
           );
@@ -244,18 +260,9 @@ const Shuffle = ({
           if (odd.length) addTween(odd, 0);
           if (even.length) addTween(even, evenStart);
         } else {
-          strips.forEach(strip => {
+          strips.forEach((strip) => {
             const d = Math.random() * maxDelay;
-            tl.to(
-              strip,
-              {
-                x: parseFloat(strip.getAttribute('data-final-x') || '0'),
-                duration,
-                ease,
-                force3D: true
-              },
-              d
-            );
+            tl.to(strip, { x: parseFloat(strip.getAttribute('data-final-x') || '0'), duration, ease, force3D: true }, d);
             if (colorFrom && colorTo) tl.fromTo(strip, { color: colorFrom }, { color: colorTo, duration, ease }, d);
           });
         }
@@ -284,12 +291,7 @@ const Shuffle = ({
         setReady(true);
       };
 
-      const st = ScrollTrigger.create({
-        trigger: el,
-        start,
-        once: triggerOnce,
-        onEnter: create
-      });
+      const st = ScrollTrigger.create({ trigger: el, start, once: triggerOnce, onEnter: create });
 
       return () => {
         st.kill();
@@ -318,21 +320,16 @@ const Shuffle = ({
         colorTo,
         triggerOnce,
         respectReducedMotion,
-        triggerOnHover
+        triggerOnHover,
       ],
-      scope: ref
+      scope: ref,
     }
   );
 
   const baseTw = 'inline-block whitespace-normal break-words will-change-transform uppercase text-[4rem] leading-none';
-  const commonStyle = {
-    textAlign,
-    fontFamily: `'Press Start 2P', sans-serif`,
-    ...style
-  };
-
   const classes = `${baseTw} ${ready ? 'visible' : 'invisible'} ${className}`.trim();
   const Tag = tag || 'p';
+  const commonStyle = { textAlign, ...style };
 
   return React.createElement(Tag, { ref: ref, className: classes, style: commonStyle }, text);
 };

--- a/src/ts-tailwind/TextAnimations/Shuffle/Shuffle.tsx
+++ b/src/ts-tailwind/TextAnimations/Shuffle/Shuffle.tsx
@@ -3,8 +3,9 @@ import { gsap } from 'gsap';
 import { ScrollTrigger } from 'gsap/ScrollTrigger';
 import { SplitText as GSAPSplitText } from 'gsap/SplitText';
 import { useGSAP } from '@gsap/react';
+import { JSX } from 'react';
 
-gsap.registerPlugin(ScrollTrigger, GSAPSplitText, useGSAP);
+gsap.registerPlugin(ScrollTrigger, GSAPSplitText);
 
 export interface ShuffleProps {
   text: string;
@@ -113,13 +114,15 @@ const Shuffle: React.FC<ShuffleProps> = ({
         }
         try {
           splitRef.current?.revert();
-        } catch {}
+        } catch { }
         splitRef.current = null;
         playingRef.current = false;
       };
 
       const build = () => {
         teardown();
+
+        const computedFont = getComputedStyle(el).fontFamily;
 
         splitRef.current = new GSAPSplitText(el, {
           type: 'chars',
@@ -155,18 +158,18 @@ const Shuffle: React.FC<ShuffleProps> = ({
 
           const firstOrig = ch.cloneNode(true) as HTMLElement;
           firstOrig.className = 'inline-block text-left';
-          Object.assign(firstOrig.style, { width: w + 'px' });
+          Object.assign(firstOrig.style, { width: w + 'px', fontFamily: computedFont });
 
           ch.setAttribute('data-orig', '1');
           ch.className = 'inline-block text-left';
-          Object.assign(ch.style, { width: w + 'px' });
+          Object.assign(ch.style, { width: w + 'px', fontFamily: computedFont });
 
           inner.appendChild(firstOrig);
           for (let k = 0; k < rolls; k++) {
             const c = ch.cloneNode(true) as HTMLElement;
             if (scrambleCharset) c.textContent = rand(scrambleCharset);
             c.className = 'inline-block text-left';
-            Object.assign(c.style, { width: w + 'px' });
+            Object.assign(c.style, { width: w + 'px', fontFamily: computedFont });
             inner.appendChild(c);
           }
           inner.appendChild(ch);
@@ -348,10 +351,14 @@ const Shuffle: React.FC<ShuffleProps> = ({
     }
   );
 
-  const baseTw = 'inline-block whitespace-normal break-words will-change-transform uppercase text-[4rem] leading-none';
+  const baseTw = 'inline-block whitespace-normal break-words will-change-transform uppercase text-2xl leading-none';
+  const userHasFont = (className && /font[-[]/i.test(className));
+
+  const fallbackFont = userHasFont ? {} : { fontFamily: `'Press Start 2P', sans-serif` };
+
   const commonStyle: React.CSSProperties = {
     textAlign,
-    fontFamily: `'Press Start 2P', sans-serif`,
+    ...fallbackFont,
     ...style
   };
 


### PR DESCRIPTION
## FIX: Shuffle Component
correct working of custom fonts `font-<custom>` usage in Tailwindcss `className` prop in Shuffle Component.
### WHAT IS BUG
when using a Shuffle component the main problem facing with Custom font using in it.. like `font-akira` or `font-[Any font]`. 
In which font is not loaded.. and prevent as default.

#### Code

```tsx
"use client"
// app/debug/page.tsx
import MyShuffle from "@/components/myShuffle";
import Shuffle from "@/components/Shuffle";
import JSXShuffle  from "@/components/JSXShuffle.jsx";

export default function Page() {


    return (
        <div className="p-6">
            <h1>2. Default Shuffle from ReactBits</h1>
            <p className="font-bold">When it use Custom Font(akira or etc) in Tailwindcss, It can't access font</p>
            {/* default Component from reactbits */}
            <Shuffle
                text="HELLO"
                shuffleDirection="right"
                duration={0.35}
                animationMode="evenodd"
                shuffleTimes={1}
                ease="power3.out"
                stagger={0.03}
                threshold={0.1}
                triggerOnce={false}
                triggerOnHover={true}
                respectReducedMotion={true}
                className="text-[3rem] font-akira" // working of custom fonts "font-<custom>" usage in tailwindcss className props in Shuffle Component which isn't loaded
            />
            <h1>1. Debugged Shuffle</h1>
            <p className="font-bold">It uses Custom Font(akira or etc) in Tailwindcss correctly</p>
            {/* component "Shuffle" that is edit by me in TypeScript */}
            <MyShuffle
                text="Hello"
                shuffleDirection="right"
                duration={0.35}
                animationMode="evenodd"
                shuffleTimes={1}
                ease="power3.out"
                stagger={0.03}
                threshold={0.1}
                triggerOnce={false}
                triggerOnHover={true}
                respectReducedMotion={true}
                className="text-[3rem] font-akira" // correct working of custom fonts "font-<custom>" usage in tailwindcss className props in Shuffle Component in TSX version
            />
            <h1>3. Debugged Shuffle JSX</h1>
            <p className="font-bold">It uses Custom Font(akira or etc) in Tailwindcss correctly</p>
            {/* component "Shuffle" that is edit by me in JSX */}
            <JSXShuffle 
                text="Hello"
                shuffleDirection="right"
                duration={0.35}
                animationMode="evenodd"
                shuffleTimes={1}
                ease="power3.out"
                stagger={0.03}
                threshold={0.1}
                triggerOnce={false}
                triggerOnHover={true}
                respectReducedMotion={true}
                className="text-[3rem] font-akira" // correct working of custom fonts "font-<custom>" usage in tailwindcss className props in Shuffle Component in JSX version
            />
        </div>
    )
}
```
### Proof

https://github.com/user-attachments/assets/df03cb2b-f821-4505-9136-fd090a77d8e1

---


#### Before going forward I show main errors that must be avoided

> [!WARNING]
> **Inline `font-family` overrides everything**

> [!WARNING]
> *getComputedStyle* usage.*

> [!WARNING]
> *useGSAP usage is not correct*


> [!IMPORTANT]
> ### Reason Why not working: 
**react bits Shuffle code didn’t show the custom font instead of applying default fonts**

1. **GSAP SplitText clones every character**

   * In your code, each character gets cloned multiple times for the shuffle animation.
   * Each clone is a **new `<span>` element**.

3. **Inline `font-family` overrides everything**

   * You had this in `commonStyle`:

   ```ts
   const commonStyle: React.CSSProperties = {
     textAlign,
     fontFamily: `'Press Start 2P', sans-serif`,
     ...style
   };
   ```

   * This sets the font on the **outer container only**, not on the cloned letters created by GSAP.
   * When GSAP animates, the cloned spans inherit **no font**, so the browser falls back to the default `sans-serif`.

4. **Tailwind classes don’t propagate through clones**

   * Tailwind applies classes to the container element.
   * GSAP wraps each character in new `<span>`s for the animation. These spans **don’t have the Tailwind class**, so the font class never reaches the animated letters.

5. **Inline style has lower priority inside GSAP clones**

   * Even if you passed `style={{ fontFamily: "CustomFont" }}`, GSAP manipulates the DOM and creates new elements that don’t inherit this style unless you explicitly apply it to each clone.

---

### 1️⃣ What `getComputedStyle` does

```ts
const style = getComputedStyle(el);
const font = style.fontFamily;
```

* It reads the **final CSS values** that the browser computed for an element.
* This includes all:

  * Tailwind classes
  * Inline styles
  * Inherited CSS
  * Default browser styles

So even if your `<Shuffle>` container has `className="font-akira"` or `style={{ fontFamily: "Retro" }}`, `getComputedStyle(el).fontFamily` will return the correct font-family string.

---

### 2️⃣ Why default code didn’t work

* You were only using `style={{ fontFamily: ... }}` on the **container**.
* GSAP clones each character into new `<span>` elements for animation.
* These new spans **don’t inherit inline styles or classes** from the container.
* Therefore, the browser defaults to `sans-serif` for all the animated characters, ignoring both Tailwind classes and inline styles.

---

### 3️⃣ Correct use

You compute the font once at build time:

```ts
const computedFont = getComputedStyle(el).fontFamily || `'Press Start 2P', sans-serif`;
```

Then explicitly apply it to **all cloned letters**:

```ts
Object.assign(firstOrig.style, { width: w + 'px', fontFamily: computedFont });
Object.assign(c.style, { width: w + 'px', fontFamily: computedFont });
Object.assign(ch.style, { width: w + 'px', fontFamily: computedFont });
```

This guarantees that:

* Tailwind font classes are respected.
* Inline `style={{ fontFamily: ... }}` is respected.
* If no font is specified, `"Press Start 2P", sans-serif` is used as a fallback internally.

---

## how it works with plugins like `ScrollTrigger` and `SplitText`.

### 1️⃣ What `useGSAP` is

`useGSAP` is a **React hook from `@gsap/react`**. Its main purposes are:

* Encapsulate GSAP animations within React lifecycle.
* Ensure animations are **registered and cleaned up** properly.
* Avoid running animations on every render unnecessarily.
* Provide a `scope` so you can target refs or DOM nodes safely.

**Typical usage:**

```ts
useGSAP(() => {
  // create GSAP timeline or animation here
  const tl = gsap.timeline();
  tl.to(ref.current, { x: 100, duration: 1 });

  return () => {
    tl.kill(); // cleanup when component unmounts or dependencies change
  };
}, {
  scope: ref,
  dependencies: [someProp]
});
```

---

### 2️⃣ How it interacts with plugins

GSAP plugins like `ScrollTrigger` and `SplitText` need to be **registered** with GSAP:

```ts
gsap.registerPlugin(ScrollTrigger, GSAPSplitText);
```

After registration:

* `ScrollTrigger` allows scroll-based triggers inside your `useGSAP` function.
* `SplitText` allows you to split text into chars, words, or lines.
* You can use these plugins inside `useGSAP` safely, targeting DOM elements via `ref` or scoped selectors.

---

> [!WARNING] 
> #### 


Important Notes for Your Component
> * `useGSAP` is **not a plugin** itself; it’s a React helper. You still need `gsap.registerPlugin()` > for actual GSAP plugins.
> * The `scope` option ensures that the animation only affects elements under that ref.
> * Returning a cleanup function from `useGSAP` ensures proper teardown when the component unmounts or  dependencies change.

