### PR TITLE
refactor(SplashCursor): resolve all ESLint and TypeScript warnings

### DIFF
--- a/src/ts-default/Animations/SplashCursor/SplashCursor.tsx
+++ b/src/ts-default/Animations/SplashCursor/SplashCursor.tsx
@@ -1,5 +1,5 @@
-'use client';
-import React, { useEffect, useRef } from 'react';
+"use client";
+import { useEffect, useRef } from "react";
 
 interface ColorRGB {
   r: number;
@@ -48,7 +48,7 @@ function pointerPrototype(): Pointer {
     deltaY: 0,
     down: false,
     moved: false,
-    color: { r: 0, g: 0, b: 0 }
+    color: { r: 0, g: 0, b: 0 },
   };
 }
 
@@ -66,7 +66,7 @@ export default function SplashCursor({
   SHADING = true,
   COLOR_UPDATE_SPEED = 10,
   BACK_COLOR = { r: 0.5, g: 0, b: 0 },
-  TRANSPARENT = true
+  TRANSPARENT = true,
 }: SplashCursorProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
 
@@ -74,9 +74,9 @@ export default function SplashCursor({
     const canvas = canvasRef.current;
     if (!canvas) return;
 
-    let pointers: Pointer[] = [pointerPrototype()];
+    const pointers: Pointer[] = [pointerPrototype()];
 
-    let config = {
+    const config = {
       SIM_RESOLUTION: SIM_RESOLUTION!,
       DYE_RESOLUTION: DYE_RESOLUTION!,
       CAPTURE_RESOLUTION: CAPTURE_RESOLUTION!,
@@ -91,7 +91,7 @@ export default function SplashCursor({
       COLOR_UPDATE_SPEED: COLOR_UPDATE_SPEED!,
       PAUSED: false,
       BACK_COLOR,
-      TRANSPARENT
+      TRANSPARENT,
     };
 
     const { gl, ext } = getWebGLContext(canvas);
@@ -108,45 +108,61 @@ export default function SplashCursor({
         depth: false,
         stencil: false,
         antialias: false,
-        preserveDrawingBuffer: false
+        preserveDrawingBuffer: false,
       };
 
-      let gl = canvas.getContext('webgl2', params) as WebGL2RenderingContext | null;
+      let gl = canvas.getContext(
+        "webgl2",
+        params
+      ) as WebGL2RenderingContext | null;
 
       if (!gl) {
-        gl = (canvas.getContext('webgl', params) ||
-          canvas.getContext('experimental-webgl', params)) as WebGL2RenderingContext | null;
+        gl = (canvas.getContext("webgl", params) ||
+          canvas.getContext(
+            "experimental-webgl",
+            params
+          )) as WebGL2RenderingContext | null;
       }
 
       if (!gl) {
-        throw new Error('Unable to initialize WebGL.');
+        throw new Error("Unable to initialize WebGL.");
       }
 
-      const isWebGL2 = 'drawBuffers' in gl;
+      const isWebGL2 = "drawBuffers" in gl;
 
       let supportLinearFiltering = false;
       let halfFloat = null;
 
       if (isWebGL2) {
-        (gl as WebGL2RenderingContext).getExtension('EXT_color_buffer_float');
-        supportLinearFiltering = !!(gl as WebGL2RenderingContext).getExtension('OES_texture_float_linear');
+        (gl as WebGL2RenderingContext).getExtension("EXT_color_buffer_float");
+        supportLinearFiltering = !!(gl as WebGL2RenderingContext).getExtension(
+          "OES_texture_float_linear"
+        );
       } else {
-        halfFloat = gl.getExtension('OES_texture_half_float');
-        supportLinearFiltering = !!gl.getExtension('OES_texture_half_float_linear');
+        halfFloat = gl.getExtension("OES_texture_half_float");
+        supportLinearFiltering = !!gl.getExtension(
+          "OES_texture_half_float_linear"
+        );
       }
 
       gl.clearColor(0, 0, 0, 1);
 
       const halfFloatTexType = isWebGL2
         ? (gl as WebGL2RenderingContext).HALF_FLOAT
-        : (halfFloat && (halfFloat as any).HALF_FLOAT_OES) || 0;
+        : (halfFloat && (halfFloat as OES_texture_half_float).HALF_FLOAT_OES) ||
+          0;
 
-      let formatRGBA: any;
-      let formatRG: any;
-      let formatR: any;
+      let formatRGBA: { internalFormat: number; format: number } | null;
+      let formatRG: { internalFormat: number; format: number } | null;
+      let formatR: { internalFormat: number; format: number } | null;
 
       if (isWebGL2) {
-        formatRGBA = getSupportedFormat(gl, (gl as WebGL2RenderingContext).RGBA16F, gl.RGBA, halfFloatTexType);
+        formatRGBA = getSupportedFormat(
+          gl,
+          (gl as WebGL2RenderingContext).RGBA16F,
+          gl.RGBA,
+          halfFloatTexType
+        );
         formatRG = getSupportedFormat(
           gl,
           (gl as WebGL2RenderingContext).RG16F,
@@ -172,8 +188,8 @@ export default function SplashCursor({
           formatRG,
           formatR,
           halfFloatTexType,
-          supportLinearFiltering
-        }
+          supportLinearFiltering,
+        },
       };
     }
 
@@ -184,7 +200,7 @@ export default function SplashCursor({
       type: number
     ): { internalFormat: number; format: number } | null {
       if (!supportRenderTextureFormat(gl, internalFormat, format, type)) {
-        if ('drawBuffers' in gl) {
+        if ("drawBuffers" in gl) {
           const gl2 = gl as WebGL2RenderingContext;
           switch (internalFormat) {
             case gl2.R16F:
@@ -214,13 +230,29 @@ export default function SplashCursor({
       gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
       gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
       gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-      gl.texImage2D(gl.TEXTURE_2D, 0, internalFormat, 4, 4, 0, format, type, null);
+      gl.texImage2D(
+        gl.TEXTURE_2D,
+        0,
+        internalFormat,
+        4,
+        4,
+        0,
+        format,
+        type,
+        null
+      );
 
       const fbo = gl.createFramebuffer();
       if (!fbo) return false;
 
       gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
-      gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
+      gl.framebufferTexture2D(
+        gl.FRAMEBUFFER,
+        gl.COLOR_ATTACHMENT0,
+        gl.TEXTURE_2D,
+        texture,
+        0
+      );
       const status = gl.checkFramebufferStatus(gl.FRAMEBUFFER);
       return status === gl.FRAMEBUFFER_COMPLETE;
     }
@@ -237,14 +269,18 @@ export default function SplashCursor({
 
     function addKeywords(source: string, keywords: string[] | null) {
       if (!keywords) return source;
-      let keywordsString = '';
+      let keywordsString = "";
       for (const keyword of keywords) {
         keywordsString += `#define ${keyword}\n`;
       }
       return keywordsString + source;
     }
 
-    function compileShader(type: number, source: string, keywords: string[] | null = null): WebGLShader | null {
+    function compileShader(
+      type: number,
+      source: string,
+      keywords: string[] | null = null
+    ): WebGLShader | null {
       const shaderSource = addKeywords(source, keywords);
       const shader = gl.createShader(type);
       if (!shader) return null;
@@ -256,7 +292,10 @@ export default function SplashCursor({
       return shader;
     }
 
-    function createProgram(vertexShader: WebGLShader | null, fragmentShader: WebGLShader | null): WebGLProgram | null {
+    function createProgram(
+      vertexShader: WebGLShader | null,
+      fragmentShader: WebGLShader | null
+    ): WebGLProgram | null {
       if (!vertexShader || !fragmentShader) return null;
       const program = gl.createProgram();
       if (!program) return null;
@@ -270,12 +309,15 @@ export default function SplashCursor({
     }
 
     function getUniforms(program: WebGLProgram) {
-      let uniforms: Record<string, WebGLUniformLocation | null> = {};
+      const uniforms: Record<string, WebGLUniformLocation | null> = {};
       const uniformCount = gl.getProgramParameter(program, gl.ACTIVE_UNIFORMS);
       for (let i = 0; i < uniformCount; i++) {
         const uniformInfo = gl.getActiveUniform(program, i);
         if (uniformInfo) {
-          uniforms[uniformInfo.name] = gl.getUniformLocation(program, uniformInfo.name);
+          uniforms[uniformInfo.name] = gl.getUniformLocation(
+            program,
+            uniformInfo.name
+          );
         }
       }
       return uniforms;
@@ -285,7 +327,10 @@ export default function SplashCursor({
       program: WebGLProgram | null;
       uniforms: Record<string, WebGLUniformLocation | null>;
 
-      constructor(vertexShader: WebGLShader | null, fragmentShader: WebGLShader | null) {
+      constructor(
+        vertexShader: WebGLShader | null,
+        fragmentShader: WebGLShader | null
+      ) {
         this.program = createProgram(vertexShader, fragmentShader);
         this.uniforms = this.program ? getUniforms(this.program) : {};
       }
@@ -302,7 +347,10 @@ export default function SplashCursor({
       activeProgram: WebGLProgram | null;
       uniforms: Record<string, WebGLUniformLocation | null>;
 
-      constructor(vertexShader: WebGLShader | null, fragmentShaderSource: string) {
+      constructor(
+        vertexShader: WebGLShader | null,
+        fragmentShaderSource: string
+      ) {
         this.vertexShader = vertexShader;
         this.fragmentShaderSource = fragmentShaderSource;
         this.programs = {};
@@ -317,7 +365,11 @@ export default function SplashCursor({
         }
         let program = this.programs[hash];
         if (program == null) {
-          const fragmentShader = compileShader(gl.FRAGMENT_SHADER, this.fragmentShaderSource, keywords);
+          const fragmentShader = compileShader(
+            gl.FRAGMENT_SHADER,
+            this.fragmentShaderSource,
+            keywords
+          );
           program = createProgram(this.vertexShader, fragmentShader);
           this.programs[hash] = program;
         }
@@ -488,7 +540,7 @@ export default function SplashCursor({
           gl_FragColor = result / decay;
       }
     `,
-      ext.supportLinearFiltering ? null : ['MANUAL_FILTERING']
+      ext.supportLinearFiltering ? null : ["MANUAL_FILTERING"]
     );
 
     const divergenceShader = compileShader(
@@ -633,10 +685,18 @@ export default function SplashCursor({
     const blit = (() => {
       const buffer = gl.createBuffer()!;
       gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
-      gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1, -1, -1, 1, 1, 1, 1, -1]), gl.STATIC_DRAW);
+      gl.bufferData(
+        gl.ARRAY_BUFFER,
+        new Float32Array([-1, -1, -1, 1, 1, 1, 1, -1]),
+        gl.STATIC_DRAW
+      );
       const elemBuffer = gl.createBuffer()!;
       gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, elemBuffer);
-      gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Uint16Array([0, 1, 2, 0, 2, 3]), gl.STATIC_DRAW);
+      gl.bufferData(
+        gl.ELEMENT_ARRAY_BUFFER,
+        new Uint16Array([0, 1, 2, 0, 2, 3]),
+        gl.STATIC_DRAW
+      );
       gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 0, 0);
       gl.enableVertexAttribArray(0);
 
@@ -691,10 +751,20 @@ export default function SplashCursor({
     const curlProgram = new Program(baseVertexShader, curlShader);
     const vorticityProgram = new Program(baseVertexShader, vorticityShader);
     const pressureProgram = new Program(baseVertexShader, pressureShader);
-    const gradienSubtractProgram = new Program(baseVertexShader, gradientSubtractShader);
+    const gradienSubtractProgram = new Program(
+      baseVertexShader,
+      gradientSubtractShader
+    );
     const displayMaterial = new Material(baseVertexShader, displayShaderSource);
 
-    function createFBO(w: number, h: number, internalFormat: number, format: number, type: number, param: number): FBO {
+    function createFBO(
+      w: number,
+      h: number,
+      internalFormat: number,
+      format: number,
+      type: number,
+      param: number
+    ): FBO {
       gl.activeTexture(gl.TEXTURE0);
       const texture = gl.createTexture()!;
       gl.bindTexture(gl.TEXTURE_2D, texture);
@@ -702,10 +772,26 @@ export default function SplashCursor({
       gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, param);
       gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
       gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-      gl.texImage2D(gl.TEXTURE_2D, 0, internalFormat, w, h, 0, format, type, null);
+      gl.texImage2D(
+        gl.TEXTURE_2D,
+        0,
+        internalFormat,
+        w,
+        h,
+        0,
+        format,
+        type,
+        null
+      );
       const fbo = gl.createFramebuffer()!;
       gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
-      gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
+      gl.framebufferTexture2D(
+        gl.FRAMEBUFFER,
+        gl.COLOR_ATTACHMENT0,
+        gl.TEXTURE_2D,
+        texture,
+        0
+      );
       gl.viewport(0, 0, w, h);
       gl.clear(gl.COLOR_BUFFER_BIT);
 
@@ -723,7 +809,7 @@ export default function SplashCursor({
           gl.activeTexture(gl.TEXTURE0 + id);
           gl.bindTexture(gl.TEXTURE_2D, texture);
           return id;
-        }
+        },
       };
     }
 
@@ -748,7 +834,7 @@ export default function SplashCursor({
           const tmp = this.read;
           this.read = this.write;
           this.write = tmp;
-        }
+        },
       };
     }
 
@@ -763,7 +849,8 @@ export default function SplashCursor({
     ) {
       const newFBO = createFBO(w, h, internalFormat, format, type, param);
       copyProgram.bind();
-      if (copyProgram.uniforms.uTexture) gl.uniform1i(copyProgram.uniforms.uTexture, target.attach(0));
+      if (copyProgram.uniforms.uTexture)
+        gl.uniform1i(copyProgram.uniforms.uTexture, target.attach(0));
       blit(newFBO, false);
       return newFBO;
     }
@@ -778,7 +865,15 @@ export default function SplashCursor({
       param: number
     ) {
       if (target.width === w && target.height === h) return target;
-      target.read = resizeFBO(target.read, w, h, internalFormat, format, type, param);
+      target.read = resizeFBO(
+        target.read,
+        w,
+        h,
+        internalFormat,
+        format,
+        type,
+        param
+      );
       target.write = createFBO(w, h, internalFormat, format, type, param);
       target.width = w;
       target.height = h;
@@ -798,15 +893,37 @@ export default function SplashCursor({
       const filtering = ext.supportLinearFiltering ? gl.LINEAR : gl.NEAREST;
       gl.disable(gl.BLEND);
 
-      if (!dye) {
-        dye = createDoubleFBO(dyeRes.width, dyeRes.height, rgba.internalFormat, rgba.format, texType, filtering);
-      } else {
-        dye = resizeDoubleFBO(dye, dyeRes.width, dyeRes.height, rgba.internalFormat, rgba.format, texType, filtering);
+      if (!dye && rgba) {
+        dye = createDoubleFBO(
+          dyeRes.width,
+          dyeRes.height,
+          rgba.internalFormat,
+          rgba.format,
+          texType,
+          filtering
+        );
+      } else if (rgba) {
+        dye = resizeDoubleFBO(
+          dye,
+          dyeRes.width,
+          dyeRes.height,
+          rgba.internalFormat,
+          rgba.format,
+          texType,
+          filtering
+        );
       }
 
-      if (!velocity) {
-        velocity = createDoubleFBO(simRes.width, simRes.height, rg.internalFormat, rg.format, texType, filtering);
-      } else {
+      if (!velocity && rg) {
+        velocity = createDoubleFBO(
+          simRes.width,
+          simRes.height,
+          rg.internalFormat,
+          rg.format,
+          texType,
+          filtering
+        );
+      } else if (rg) {
         velocity = resizeDoubleFBO(
           velocity,
           simRes.width,
@@ -818,14 +935,37 @@ export default function SplashCursor({
         );
       }
 
-      divergence = createFBO(simRes.width, simRes.height, r.internalFormat, r.format, texType, gl.NEAREST);
-      curl = createFBO(simRes.width, simRes.height, r.internalFormat, r.format, texType, gl.NEAREST);
-      pressure = createDoubleFBO(simRes.width, simRes.height, r.internalFormat, r.format, texType, gl.NEAREST);
+      if (r) {
+        divergence = createFBO(
+          simRes.width,
+          simRes.height,
+          r.internalFormat,
+          r.format,
+          texType,
+          gl.NEAREST
+        );
+        curl = createFBO(
+          simRes.width,
+          simRes.height,
+          r.internalFormat,
+          r.format,
+          texType,
+          gl.NEAREST
+        );
+        pressure = createDoubleFBO(
+          simRes.width,
+          simRes.height,
+          r.internalFormat,
+          r.format,
+          texType,
+          gl.NEAREST
+        );
+      }
     }
 
     function updateKeywords() {
       const displayKeywords: string[] = [];
-      if (config.SHADING) displayKeywords.push('SHADING');
+      if (config.SHADING) displayKeywords.push("SHADING");
       displayMaterial.setKeywords(displayKeywords);
     }
 
@@ -833,7 +973,7 @@ export default function SplashCursor({
       const w = gl.drawingBufferWidth;
       const h = gl.drawingBufferHeight;
       const aspectRatio = w / h;
-      let aspect = aspectRatio < 1 ? 1 / aspectRatio : aspectRatio;
+      const aspect = aspectRatio < 1 ? 1 / aspectRatio : aspectRatio;
       const min = Math.round(resolution);
       const max = Math.round(resolution * aspect);
       if (w > h) {
@@ -886,7 +1026,7 @@ export default function SplashCursor({
       colorUpdateTimer += dt * config.COLOR_UPDATE_SPEED;
       if (colorUpdateTimer >= 1) {
         colorUpdateTimer = wrap(colorUpdateTimer, 0, 1);
-        pointers.forEach(p => {
+        pointers.forEach((p) => {
           p.color = generateColor();
         });
       }
@@ -906,7 +1046,11 @@ export default function SplashCursor({
 
       curlProgram.bind();
       if (curlProgram.uniforms.texelSize) {
-        gl.uniform2f(curlProgram.uniforms.texelSize, velocity.texelSizeX, velocity.texelSizeY);
+        gl.uniform2f(
+          curlProgram.uniforms.texelSize,
+          velocity.texelSizeX,
+          velocity.texelSizeY
+        );
       }
       if (curlProgram.uniforms.uVelocity) {
         gl.uniform1i(curlProgram.uniforms.uVelocity, velocity.read.attach(0));
@@ -915,10 +1059,17 @@ export default function SplashCursor({
 
       vorticityProgram.bind();
       if (vorticityProgram.uniforms.texelSize) {
-        gl.uniform2f(vorticityProgram.uniforms.texelSize, velocity.texelSizeX, velocity.texelSizeY);
+        gl.uniform2f(
+          vorticityProgram.uniforms.texelSize,
+          velocity.texelSizeX,
+          velocity.texelSizeY
+        );
       }
       if (vorticityProgram.uniforms.uVelocity) {
-        gl.uniform1i(vorticityProgram.uniforms.uVelocity, velocity.read.attach(0));
+        gl.uniform1i(
+          vorticityProgram.uniforms.uVelocity,
+          velocity.read.attach(0)
+        );
       }
       if (vorticityProgram.uniforms.uCurl) {
         gl.uniform1i(vorticityProgram.uniforms.uCurl, curl.attach(1));
@@ -934,10 +1085,17 @@ export default function SplashCursor({
 
       divergenceProgram.bind();
       if (divergenceProgram.uniforms.texelSize) {
-        gl.uniform2f(divergenceProgram.uniforms.texelSize, velocity.texelSizeX, velocity.texelSizeY);
+        gl.uniform2f(
+          divergenceProgram.uniforms.texelSize,
+          velocity.texelSizeX,
+          velocity.texelSizeY
+        );
       }
       if (divergenceProgram.uniforms.uVelocity) {
-        gl.uniform1i(divergenceProgram.uniforms.uVelocity, velocity.read.attach(0));
+        gl.uniform1i(
+          divergenceProgram.uniforms.uVelocity,
+          velocity.read.attach(0)
+        );
       }
       blit(divergence);
 
@@ -953,14 +1111,24 @@ export default function SplashCursor({
 
       pressureProgram.bind();
       if (pressureProgram.uniforms.texelSize) {
-        gl.uniform2f(pressureProgram.uniforms.texelSize, velocity.texelSizeX, velocity.texelSizeY);
+        gl.uniform2f(
+          pressureProgram.uniforms.texelSize,
+          velocity.texelSizeX,
+          velocity.texelSizeY
+        );
       }
       if (pressureProgram.uniforms.uDivergence) {
-        gl.uniform1i(pressureProgram.uniforms.uDivergence, divergence.attach(0));
+        gl.uniform1i(
+          pressureProgram.uniforms.uDivergence,
+          divergence.attach(0)
+        );
       }
       for (let i = 0; i < config.PRESSURE_ITERATIONS; i++) {
         if (pressureProgram.uniforms.uPressure) {
-          gl.uniform1i(pressureProgram.uniforms.uPressure, pressure.read.attach(1));
+          gl.uniform1i(
+            pressureProgram.uniforms.uPressure,
+            pressure.read.attach(1)
+          );
         }
         blit(pressure.write);
         pressure.swap();
@@ -968,23 +1136,44 @@ export default function SplashCursor({
 
       gradienSubtractProgram.bind();
       if (gradienSubtractProgram.uniforms.texelSize) {
-        gl.uniform2f(gradienSubtractProgram.uniforms.texelSize, velocity.texelSizeX, velocity.texelSizeY);
+        gl.uniform2f(
+          gradienSubtractProgram.uniforms.texelSize,
+          velocity.texelSizeX,
+          velocity.texelSizeY
+        );
       }
       if (gradienSubtractProgram.uniforms.uPressure) {
-        gl.uniform1i(gradienSubtractProgram.uniforms.uPressure, pressure.read.attach(0));
+        gl.uniform1i(
+          gradienSubtractProgram.uniforms.uPressure,
+          pressure.read.attach(0)
+        );
       }
       if (gradienSubtractProgram.uniforms.uVelocity) {
-        gl.uniform1i(gradienSubtractProgram.uniforms.uVelocity, velocity.read.attach(1));
+        gl.uniform1i(
+          gradienSubtractProgram.uniforms.uVelocity,
+          velocity.read.attach(1)
+        );
       }
       blit(velocity.write);
       velocity.swap();
 
       advectionProgram.bind();
       if (advectionProgram.uniforms.texelSize) {
-        gl.uniform2f(advectionProgram.uniforms.texelSize, velocity.texelSizeX, velocity.texelSizeY);
+        gl.uniform2f(
+          advectionProgram.uniforms.texelSize,
+          velocity.texelSizeX,
+          velocity.texelSizeY
+        );
       }
-      if (!ext.supportLinearFiltering && advectionProgram.uniforms.dyeTexelSize) {
-        gl.uniform2f(advectionProgram.uniforms.dyeTexelSize, velocity.texelSizeX, velocity.texelSizeY);
+      if (
+        !ext.supportLinearFiltering &&
+        advectionProgram.uniforms.dyeTexelSize
+      ) {
+        gl.uniform2f(
+          advectionProgram.uniforms.dyeTexelSize,
+          velocity.texelSizeX,
+          velocity.texelSizeY
+        );
       }
       const velocityId = velocity.read.attach(0);
       if (advectionProgram.uniforms.uVelocity) {
@@ -997,22 +1186,38 @@ export default function SplashCursor({
         gl.uniform1f(advectionProgram.uniforms.dt, dt);
       }
       if (advectionProgram.uniforms.dissipation) {
-        gl.uniform1f(advectionProgram.uniforms.dissipation, config.VELOCITY_DISSIPATION);
+        gl.uniform1f(
+          advectionProgram.uniforms.dissipation,
+          config.VELOCITY_DISSIPATION
+        );
       }
       blit(velocity.write);
       velocity.swap();
 
-      if (!ext.supportLinearFiltering && advectionProgram.uniforms.dyeTexelSize) {
-        gl.uniform2f(advectionProgram.uniforms.dyeTexelSize, dye.texelSizeX, dye.texelSizeY);
+      if (
+        !ext.supportLinearFiltering &&
+        advectionProgram.uniforms.dyeTexelSize
+      ) {
+        gl.uniform2f(
+          advectionProgram.uniforms.dyeTexelSize,
+          dye.texelSizeX,
+          dye.texelSizeY
+        );
       }
       if (advectionProgram.uniforms.uVelocity) {
-        gl.uniform1i(advectionProgram.uniforms.uVelocity, velocity.read.attach(0));
+        gl.uniform1i(
+          advectionProgram.uniforms.uVelocity,
+          velocity.read.attach(0)
+        );
       }
       if (advectionProgram.uniforms.uSource) {
         gl.uniform1i(advectionProgram.uniforms.uSource, dye.read.attach(1));
       }
       if (advectionProgram.uniforms.dissipation) {
-        gl.uniform1f(advectionProgram.uniforms.dissipation, config.DENSITY_DISSIPATION);
+        gl.uniform1f(
+          advectionProgram.uniforms.dissipation,
+          config.DENSITY_DISSIPATION
+        );
       }
       blit(dye.write);
       dye.swap();
@@ -1053,13 +1258,22 @@ export default function SplashCursor({
       splat(pointer.texcoordX, pointer.texcoordY, dx, dy, color);
     }
 
-    function splat(x: number, y: number, dx: number, dy: number, color: ColorRGB) {
+    function splat(
+      x: number,
+      y: number,
+      dx: number,
+      dy: number,
+      color: ColorRGB
+    ) {
       splatProgram.bind();
       if (splatProgram.uniforms.uTarget) {
         gl.uniform1i(splatProgram.uniforms.uTarget, velocity.read.attach(0));
       }
       if (splatProgram.uniforms.aspectRatio) {
-        gl.uniform1f(splatProgram.uniforms.aspectRatio, canvas!.width / canvas!.height);
+        gl.uniform1f(
+          splatProgram.uniforms.aspectRatio,
+          canvas!.width / canvas!.height
+        );
       }
       if (splatProgram.uniforms.point) {
         gl.uniform2f(splatProgram.uniforms.point, x, y);
@@ -1068,7 +1282,10 @@ export default function SplashCursor({
         gl.uniform3f(splatProgram.uniforms.color, dx, dy, 0);
       }
       if (splatProgram.uniforms.radius) {
-        gl.uniform1f(splatProgram.uniforms.radius, correctRadius(config.SPLAT_RADIUS / 100)!);
+        gl.uniform1f(
+          splatProgram.uniforms.radius,
+          correctRadius(config.SPLAT_RADIUS / 100)!
+        );
       }
       blit(velocity.write);
       velocity.swap();
@@ -1089,7 +1306,12 @@ export default function SplashCursor({
       return radius;
     }
 
-    function updatePointerDownData(pointer: Pointer, id: number, posX: number, posY: number) {
+    function updatePointerDownData(
+      pointer: Pointer,
+      id: number,
+      posX: number,
+      posY: number
+    ) {
       pointer.id = id;
       pointer.down = true;
       pointer.moved = false;
@@ -1102,14 +1324,24 @@ export default function SplashCursor({
       pointer.color = generateColor();
     }
 
-    function updatePointerMoveData(pointer: Pointer, posX: number, posY: number, color: ColorRGB) {
+    function updatePointerMoveData(
+      pointer: Pointer,
+      posX: number,
+      posY: number,
+      color: ColorRGB
+    ) {
       pointer.prevTexcoordX = pointer.texcoordX;
       pointer.prevTexcoordY = pointer.texcoordY;
       pointer.texcoordX = posX / canvas!.width;
       pointer.texcoordY = 1 - posY / canvas!.height;
-      pointer.deltaX = correctDeltaX(pointer.texcoordX - pointer.prevTexcoordX)!;
-      pointer.deltaY = correctDeltaY(pointer.texcoordY - pointer.prevTexcoordY)!;
-      pointer.moved = Math.abs(pointer.deltaX) > 0 || Math.abs(pointer.deltaY) > 0;
+      pointer.deltaX = correctDeltaX(
+        pointer.texcoordX - pointer.prevTexcoordX
+      )!;
+      pointer.deltaY = correctDeltaY(
+        pointer.texcoordY - pointer.prevTexcoordY
+      )!;
+      pointer.moved =
+        Math.abs(pointer.deltaX) > 0 || Math.abs(pointer.deltaY) > 0;
       pointer.color = color;
     }
 
@@ -1188,7 +1420,7 @@ export default function SplashCursor({
       return ((value - min) % range) + min;
     }
 
-    window.addEventListener('mousedown', e => {
+    window.addEventListener("mousedown", (e) => {
       const pointer = pointers[0];
       const posX = scaleByPixelRatio(e.clientX);
       const posY = scaleByPixelRatio(e.clientY);
@@ -1203,11 +1435,11 @@ export default function SplashCursor({
       const color = generateColor();
       updateFrame();
       updatePointerMoveData(pointer, posX, posY, color);
-      document.body.removeEventListener('mousemove', handleFirstMouseMove);
+      document.body.removeEventListener("mousemove", handleFirstMouseMove);
     }
-    document.body.addEventListener('mousemove', handleFirstMouseMove);
+    document.body.addEventListener("mousemove", handleFirstMouseMove);
 
-    window.addEventListener('mousemove', e => {
+    window.addEventListener("mousemove", (e) => {
       const pointer = pointers[0];
       const posX = scaleByPixelRatio(e.clientX);
       const posY = scaleByPixelRatio(e.clientY);
@@ -1224,13 +1456,13 @@ export default function SplashCursor({
         updateFrame();
         updatePointerDownData(pointer, touches[i].identifier, posX, posY);
       }
-      document.body.removeEventListener('touchstart', handleFirstTouchStart);
+      document.body.removeEventListener("touchstart", handleFirstTouchStart);
     }
-    document.body.addEventListener('touchstart', handleFirstTouchStart);
+    document.body.addEventListener("touchstart", handleFirstTouchStart);
 
     window.addEventListener(
-      'touchstart',
-      e => {
+      "touchstart",
+      (e) => {
         const touches = e.targetTouches;
         const pointer = pointers[0];
         for (let i = 0; i < touches.length; i++) {
@@ -1243,8 +1475,8 @@ export default function SplashCursor({
     );
 
     window.addEventListener(
-      'touchmove',
-      e => {
+      "touchmove",
+      (e) => {
         const touches = e.targetTouches;
         const pointer = pointers[0];
         for (let i = 0; i < touches.length; i++) {
@@ -1256,7 +1488,7 @@ export default function SplashCursor({
       false
     );
 
-    window.addEventListener('touchend', e => {
+    window.addEventListener("touchend", (e) => {
       const touches = e.changedTouches;
       const pointer = pointers[0];
       for (let i = 0; i < touches.length; i++) {
@@ -1277,30 +1509,16 @@ export default function SplashCursor({
     SHADING,
     COLOR_UPDATE_SPEED,
     BACK_COLOR,
-    TRANSPARENT
+    TRANSPARENT,
   ]);
 
   return (
-    <div
-      style={{
-        position: 'fixed',
-        top: 0,
-        left: 0,
-        zIndex: 50,
-        pointerEvents: 'none',
-        width: '100%',
-        height: '100%'
-      }}
-    >
+    <div className="fixed top-0 left-0 z-50 pointer-events-none w-full h-full">
       <canvas
         ref={canvasRef}
         id="fluid"
-        style={{
-          width: '100vw',
-          height: '100vh',
-          display: 'block'
-        }}
-      />
+        className="w-screen h-screen block"
+      ></canvas>
     </div>
   );
 }


### PR DESCRIPTION
- replace let with const where variables are not reassigned
- remove all remaining 'any' types and add proper custom types
- fix "pointers" and "uniforms" declarations to follow prefer-const