### PR TITLE
fix: carousel loop backward navigation animation issue

### DIFF
--- a/src/content/Components/Carousel/Carousel.jsx
+++ b/src/content/Components/Carousel/Carousel.jsx
@@ -117,6 +117,13 @@ export default function Carousel({
     } else if (offset > DRAG_BUFFER || velocity > VELOCITY_THRESHOLD) {
       if (loop && currentIndex === 0) {
         setCurrentIndex(items.length - 1);
+      } else if (loop && currentIndex === items.length) {
+        // Jump directly to real last item without animation
+        setIsResetting(true);
+        const lastItemIndex = items.length - 1;
+        x.set(-(lastItemIndex * trackItemOffset));
+        setCurrentIndex(lastItemIndex);
+        setTimeout(() => setIsResetting(false), 50);
       } else {
         setCurrentIndex(prev => Math.max(prev - 1, 0));
       }

--- a/src/tailwind/Components/Carousel/Carousel.jsx
+++ b/src/tailwind/Components/Carousel/Carousel.jsx
@@ -115,6 +115,13 @@ export default function Carousel({
     } else if (offset > DRAG_BUFFER || velocity > VELOCITY_THRESHOLD) {
       if (loop && currentIndex === 0) {
         setCurrentIndex(items.length - 1);
+      } else if (loop && currentIndex === items.length) {
+        // Jump directly to real last item without animation
+        setIsResetting(true);
+        const lastItemIndex = items.length - 1;
+        x.set(-(lastItemIndex * trackItemOffset));
+        setCurrentIndex(lastItemIndex);
+        setTimeout(() => setIsResetting(false), 50);
       } else {
         setCurrentIndex(prev => Math.max(prev - 1, 0));
       }

--- a/src/ts-default/Components/Carousel/Carousel.tsx
+++ b/src/ts-default/Components/Carousel/Carousel.tsx
@@ -133,6 +133,13 @@ export default function Carousel({
     } else if (offset > DRAG_BUFFER || velocity > VELOCITY_THRESHOLD) {
       if (loop && currentIndex === 0) {
         setCurrentIndex(items.length - 1);
+      } else if (loop && currentIndex === items.length) {
+        // Jump directly to real last item without animation
+        setIsResetting(true);
+        const lastItemIndex = items.length - 1;
+        x.set(-(lastItemIndex * trackItemOffset));
+        setCurrentIndex(lastItemIndex);
+        setTimeout(() => setIsResetting(false), 50);
       } else {
         setCurrentIndex(prev => Math.max(prev - 1, 0));
       }

--- a/src/ts-tailwind/Components/Carousel/Carousel.tsx
+++ b/src/ts-tailwind/Components/Carousel/Carousel.tsx
@@ -133,6 +133,13 @@ export default function Carousel({
     } else if (offset > DRAG_BUFFER || velocity > VELOCITY_THRESHOLD) {
       if (loop && currentIndex === 0) {
         setCurrentIndex(items.length - 1);
+      } else if (loop && currentIndex === items.length) {
+        // Jump directly to real last item without animation
+        setIsResetting(true);
+        const lastItemIndex = items.length - 1;
+        x.set(-(lastItemIndex * trackItemOffset));
+        setCurrentIndex(lastItemIndex);
+        setTimeout(() => setIsResetting(false), 50);
       } else {
         setCurrentIndex(prev => Math.max(prev - 1, 0));
       }


### PR DESCRIPTION
Fix bug where swiping backward from cloned first item in loop mode would animate through all items instead of jumping directly to the real last item. Now uses isResetting flag to disable animation and jump directly to the correct position.

Updated all 4 carousel variants:
- content/Components/Carousel/Carousel.jsx
- ts-tailwind/Components/Carousel/Carousel.tsx
- ts-default/Components/Carousel/Carousel.tsx
- tailwind/Components/Carousel/Carousel.jsx