### PR TITLE
Alphabetically sorted component categories for easier navigation

### DIFF
--- a/src/constants/Categories.js
+++ b/src/constants/Categories.js
@@ -14,7 +14,7 @@ export const NEW = [
 export const UPDATED = ['Profile Card', 'Logo Loop', 'Animated Content', 'Fade Content', 'Stack'];
 
 // Used for main sidebar navigation
-export const CATEGORIES = [
+const CATEGORIES = [
   {
     name: 'Get Started',
     subcategories: ['Introduction', 'Installation', 'MCP', 'Index']
@@ -159,3 +159,9 @@ export const CATEGORIES = [
     ]
   }
 ];
+
+CATEGORIES.forEach(cat => {
+  cat.subcategories.sort((a, b) => a.localeCompare(b));
+});
+
+export {CATEGORIES};


### PR DESCRIPTION
I was browsing through the React Bits website and noticed that the component list wasn’t in alphabetical order. I found myself taking a little extra time to find what I was looking for, so I thought it might help to sort the categories alphabetically.

It’s not a big change, but from a user’s point of view it does make navigation a bit smoother, especially as the list grows. I’ve gone ahead and opened a PR with the update.

Thanks for taking the time to review it, happy to make any changes if needed!