### PR TITLE
fix: public readme icon is old

### DIFF
--- a/public/README.md
+++ b/public/README.md
@@ -1,5 +1,6 @@
+<div align="center">    <img src="https://github.com/EnderRomantice/react-bits/blob/main/public/favicon-32x32.png" alt="react-bits logo" height="200"></div>
 <div align="center">
-    <img src="https://github.com/EnderRomantice/react-bits/blob/main/public/favicon-32x32.png" alt="react-bits logo" height="200">Welcome to React Bits, the go-to open source library for high quality animated React components!
+Welcome to React Bits, the go-to open source library for high quality animated React components!
 </div>
 
 


### PR DESCRIPTION
<img width="1455" height="146" alt="image" src="https://github.com/user-attachments/assets/26539bc2-7c83-43ce-8ee5-80f5db9b3ebb" />
<img width="1452" height="247" alt="image" src="https://github.com/user-attachments/assets/24a1b052-ec1e-43d2-8115-3e974879b93c" />
