### PR TITLE
Fix: Remove redundant CSS import in LightPillar (Tailwind variants)

### DIFF
--- a/src/tailwind/Backgrounds/LightPillar/LightPillar.jsx
+++ b/src/tailwind/Backgrounds/LightPillar/LightPillar.jsx
@@ -1,6 +1,5 @@
 import { useRef, useEffect, useState } from 'react';
 import * as THREE from 'three';
-import './LightPillar.css';
 
 const LightPillar = ({
   topColor = '#5227FF',


### PR DESCRIPTION
## Description
This PR fixes a bug in the **Tailwind variants** of the `LightPillar` component where a CSS file was being incorrectly imported.

### The Issue
The component contained `import './LightPillar.css';` even though the Tailwind variants are fully styled using utility classes. This import causes a build error (`Module not found`) for developers who copy the Tailwind component code without also copying the CSS file, which defeats the purpose of the Tailwind variant.

### Changes Made
- Removed the redundant `import './LightPillar.css';` line from `LightPillar.jsx` (JS + Tailwind).
- Verified `LightPillar.tsx` (TS + Tailwind) does not have this issue. It is already clean 

- Hence All 4 variants of component are checked, only the JS+Tailwind version had the error.