### PR TITLE
[ FEAT ] : Added Up & Down Support in TextAnimations Shuffle

### DIFF
--- a/src/content/TextAnimations/Shuffle/Shuffle.jsx
+++ b/src/content/TextAnimations/Shuffle/Shuffle.jsx
@@ -123,6 +123,7 @@ const Shuffle = ({
           if (!parent) return;
 
           const w = ch.getBoundingClientRect().width;
+          const h = ch.getBoundingClientRect().height;
           if (!w) return;
 
           const wrap = document.createElement('span');
@@ -130,13 +131,14 @@ const Shuffle = ({
             display: 'inline-block',
             overflow: 'hidden',
             width: w + 'px',
-            verticalAlign: 'baseline'
+            height: shuffleDirection === 'up' || shuffleDirection === 'down' ? h + 'px' : 'auto',
+            verticalAlign: 'bottom'
           });
 
           const inner = document.createElement('span');
           Object.assign(inner.style, {
             display: 'inline-block',
-            whiteSpace: 'nowrap',
+            whiteSpace: shuffleDirection === 'up' || shuffleDirection === 'down' ? 'normal' : 'nowrap',
             willChange: 'transform'
           });
 
@@ -144,38 +146,71 @@ const Shuffle = ({
           wrap.appendChild(inner);
 
           const firstOrig = ch.cloneNode(true);
-          Object.assign(firstOrig.style, { display: 'inline-block', width: w + 'px', textAlign: 'center' });
+          Object.assign(firstOrig.style, {
+            display: shuffleDirection === 'up' || shuffleDirection === 'down' ? 'block' : 'inline-block',
+            width: w + 'px',
+            textAlign: 'center'
+          });
 
           ch.setAttribute('data-orig', '1');
-          Object.assign(ch.style, { display: 'inline-block', width: w + 'px', textAlign: 'center' });
+          Object.assign(ch.style, {
+            display: shuffleDirection === 'up' || shuffleDirection === 'down' ? 'block' : 'inline-block',
+            width: w + 'px',
+            textAlign: 'center'
+          });
 
           inner.appendChild(firstOrig);
           for (let k = 0; k < rolls; k++) {
             const c = ch.cloneNode(true);
             if (scrambleCharset) c.textContent = rand(scrambleCharset);
-            Object.assign(c.style, { display: 'inline-block', width: w + 'px', textAlign: 'center' });
+            Object.assign(c.style, {
+              display: shuffleDirection === 'up' || shuffleDirection === 'down' ? 'block' : 'inline-block',
+              width: w + 'px',
+              textAlign: 'center'
+            });
             inner.appendChild(c);
           }
           inner.appendChild(ch);
 
           const steps = rolls + 1;
-          let startX = 0;
-          let finalX = -steps * w;
-          if (shuffleDirection === 'right') {
+
+          if (shuffleDirection === 'right' || shuffleDirection === 'down') {
             const firstCopy = inner.firstElementChild;
             const real = inner.lastElementChild;
             if (real) inner.insertBefore(real, inner.firstChild);
             if (firstCopy) inner.appendChild(firstCopy);
-            startX = -steps * w;
-            finalX = 0;
           }
 
-          gsap.set(inner, { x: startX, force3D: true });
+          let startX = 0;
+          let finalX = 0;
+          let startY = 0;
+          let finalY = 0;
+
+          if (shuffleDirection === 'right') {
+            startX = -steps * w;
+            finalX = 0;
+          } else if (shuffleDirection === 'left') {
+            startX = 0;
+            finalX = -steps * w;
+          } else if (shuffleDirection === 'down') {
+            startY = -steps * h;
+            finalY = 0;
+          } else if (shuffleDirection === 'up') {
+            startY = 0;
+            finalY = -steps * h;
+          }
+
+          if (shuffleDirection === 'left' || shuffleDirection === 'right') {
+            gsap.set(inner, { x: startX, y: 0, force3D: true });
+            inner.setAttribute('data-start-x', String(startX));
+            inner.setAttribute('data-final-x', String(finalX));
+          } else {
+            gsap.set(inner, { x: 0, y: startY, force3D: true });
+            inner.setAttribute('data-start-y', String(startY));
+            inner.setAttribute('data-final-y', String(finalY));
+          }
+
           if (colorFrom) inner.style.color = colorFrom;
-
-          inner.setAttribute('data-final-x', String(finalX));
-          inner.setAttribute('data-start-x', String(startX));
-
           wrappersRef.current.push(wrap);
         });
       };
@@ -211,6 +246,7 @@ const Shuffle = ({
         if (!strips.length) return;
 
         playingRef.current = true;
+        const isVertical = shuffleDirection === 'up' || shuffleDirection === 'down';
 
         const tl = gsap.timeline({
           smoothChildTiming: true,
@@ -218,7 +254,11 @@ const Shuffle = ({
           repeatDelay: loop ? loopDelay : 0,
           onRepeat: () => {
             if (scrambleCharset) randomizeScrambles();
-            gsap.set(strips, { x: (i, t) => parseFloat(t.getAttribute('data-start-x') || '0') });
+            if (isVertical) {
+              gsap.set(strips, { y: (i, t) => parseFloat(t.getAttribute('data-start-y') || '0') });
+            } else {
+              gsap.set(strips, { x: (i, t) => parseFloat(t.getAttribute('data-start-x') || '0') });
+            }
             onShuffleComplete?.();
           },
           onComplete: () => {
@@ -233,17 +273,20 @@ const Shuffle = ({
         });
 
         const addTween = (targets, at) => {
-          tl.to(
-            targets,
-            {
-              x: (i, t) => parseFloat(t.getAttribute('data-final-x') || '0'),
-              duration,
-              ease,
-              force3D: true,
-              stagger: animationMode === 'evenodd' ? stagger : 0
-            },
-            at
-          );
+          const vars = {
+            duration,
+            ease,
+            force3D: true,
+            stagger: animationMode === 'evenodd' ? stagger : 0
+          };
+          if (isVertical) {
+            vars.y = (i, t) => parseFloat(t.getAttribute('data-final-y') || '0');
+          } else {
+            vars.x = (i, t) => parseFloat(t.getAttribute('data-final-x') || '0');
+          }
+
+          tl.to(targets, vars, at);
+
           if (colorFrom && colorTo) {
             tl.to(targets, { color: colorTo, duration, ease }, at);
           }
@@ -259,16 +302,17 @@ const Shuffle = ({
         } else {
           strips.forEach(strip => {
             const d = Math.random() * maxDelay;
-            tl.to(
-              strip,
-              {
-                x: parseFloat(strip.getAttribute('data-final-x') || '0'),
-                duration,
-                ease,
-                force3D: true
-              },
-              d
-            );
+            const vars = {
+              duration,
+              ease,
+              force3D: true
+            };
+            if (isVertical) {
+              vars.y = parseFloat(strip.getAttribute('data-final-y') || '0');
+            } else {
+              vars.x = parseFloat(strip.getAttribute('data-final-x') || '0');
+            }
+            tl.to(strip, vars, d);
             if (colorFrom && colorTo) tl.fromTo(strip, { color: colorFrom }, { color: colorTo, duration, ease }, d);
           });
         }

--- a/src/demo/TextAnimations/ShuffleDemo.jsx
+++ b/src/demo/TextAnimations/ShuffleDemo.jsx
@@ -36,7 +36,7 @@ const ShuffleDemo = () => {
       { name: 'style', type: 'object', default: '{}', description: 'Inline styles applied to the wrapper element.' },
       {
         name: 'shuffleDirection',
-        type: '"left" | "right"',
+        type: '"left" | "right" | "up" | "down"',
         default: '"right"',
         description: 'Direction the per-letter strip slides to reveal the final character.'
       },
@@ -140,7 +140,9 @@ const ShuffleDemo = () => {
 
   const directionOptions = [
     { label: 'Right', value: 'right' },
-    { label: 'Left', value: 'left' }
+    { label: 'Left', value: 'left' },
+    { label: 'Up', value: 'up' },
+    { label: 'Down', value: 'down' }
   ];
 
   const easeOptions = [
@@ -156,7 +158,7 @@ const ShuffleDemo = () => {
         <PreviewTab>
           <Box
             position="relative"
-            className="demo-container flex items-center justify-center"
+            className="flex justify-center items-center demo-container"
             h={400}
             overflow="hidden"
           >

--- a/src/ts-default/TextAnimations/Shuffle/Shuffle.tsx
+++ b/src/ts-default/TextAnimations/Shuffle/Shuffle.tsx
@@ -11,7 +11,7 @@ export interface ShuffleProps {
   text: string;
   className?: string;
   style?: React.CSSProperties;
-  shuffleDirection?: 'left' | 'right';
+  shuffleDirection?: 'left' | 'right' | 'up' | 'down';
   duration?: number;
   maxDelay?: number;
   ease?: string | ((t: number) => number);
@@ -145,6 +145,7 @@ const Shuffle: React.FC<ShuffleProps> = ({
           if (!parent) return;
 
           const w = ch.getBoundingClientRect().width;
+          const h = ch.getBoundingClientRect().height;
           if (!w) return;
 
           const wrap = document.createElement('span');
@@ -152,13 +153,14 @@ const Shuffle: React.FC<ShuffleProps> = ({
             display: 'inline-block',
             overflow: 'hidden',
             width: w + 'px',
-            verticalAlign: 'baseline'
+            height: shuffleDirection === 'up' || shuffleDirection === 'down' ? h + 'px' : 'auto',
+            verticalAlign: 'bottom'
           });
 
           const inner = document.createElement('span');
           Object.assign(inner.style, {
             display: 'inline-block',
-            whiteSpace: 'nowrap',
+            whiteSpace: shuffleDirection === 'up' || shuffleDirection === 'down' ? 'normal' : 'nowrap',
             willChange: 'transform'
           });
 
@@ -166,38 +168,71 @@ const Shuffle: React.FC<ShuffleProps> = ({
           wrap.appendChild(inner);
 
           const firstOrig = ch.cloneNode(true) as HTMLElement;
-          Object.assign(firstOrig.style, { display: 'inline-block', width: w + 'px', textAlign: 'center' });
+          Object.assign(firstOrig.style, {
+            display: shuffleDirection === 'up' || shuffleDirection === 'down' ? 'block' : 'inline-block',
+            width: w + 'px',
+            textAlign: 'center'
+          });
 
           ch.setAttribute('data-orig', '1');
-          Object.assign(ch.style, { display: 'inline-block', width: w + 'px', textAlign: 'center' });
+          Object.assign(ch.style, {
+            display: shuffleDirection === 'up' || shuffleDirection === 'down' ? 'block' : 'inline-block',
+            width: w + 'px',
+            textAlign: 'center'
+          });
 
           inner.appendChild(firstOrig);
           for (let k = 0; k < rolls; k++) {
             const c = ch.cloneNode(true) as HTMLElement;
             if (scrambleCharset) c.textContent = rand(scrambleCharset);
-            Object.assign(c.style, { display: 'inline-block', width: w + 'px', textAlign: 'center' });
+            Object.assign(c.style, {
+              display: shuffleDirection === 'up' || shuffleDirection === 'down' ? 'block' : 'inline-block',
+              width: w + 'px',
+              textAlign: 'center'
+            });
             inner.appendChild(c);
           }
           inner.appendChild(ch);
 
           const steps = rolls + 1;
-          let startX = 0;
-          let finalX = -steps * w;
-          if (shuffleDirection === 'right') {
+
+          if (shuffleDirection === 'right' || shuffleDirection === 'down') {
             const firstCopy = inner.firstElementChild as HTMLElement | null;
             const real = inner.lastElementChild as HTMLElement | null;
             if (real) inner.insertBefore(real, inner.firstChild);
             if (firstCopy) inner.appendChild(firstCopy);
-            startX = -steps * w;
-            finalX = 0;
           }
 
-          gsap.set(inner, { x: startX, force3D: true });
+          let startX = 0;
+          let finalX = 0;
+          let startY = 0;
+          let finalY = 0;
+
+          if (shuffleDirection === 'right') {
+            startX = -steps * w;
+            finalX = 0;
+          } else if (shuffleDirection === 'left') {
+            startX = 0;
+            finalX = -steps * w;
+          } else if (shuffleDirection === 'down') {
+            startY = -steps * h;
+            finalY = 0;
+          } else if (shuffleDirection === 'up') {
+            startY = 0;
+            finalY = -steps * h;
+          }
+
+          if (shuffleDirection === 'left' || shuffleDirection === 'right') {
+            gsap.set(inner, { x: startX, y: 0, force3D: true });
+            inner.setAttribute('data-start-x', String(startX));
+            inner.setAttribute('data-final-x', String(finalX));
+          } else {
+            gsap.set(inner, { x: 0, y: startY, force3D: true });
+            inner.setAttribute('data-start-y', String(startY));
+            inner.setAttribute('data-final-y', String(finalY));
+          }
+
           if (colorFrom) (inner.style as any).color = colorFrom;
-
-          inner.setAttribute('data-final-x', String(finalX));
-          inner.setAttribute('data-start-x', String(startX));
-
           wrappersRef.current.push(wrap);
         });
       };
@@ -233,6 +268,7 @@ const Shuffle: React.FC<ShuffleProps> = ({
         if (!strips.length) return;
 
         playingRef.current = true;
+        const isVertical = shuffleDirection === 'up' || shuffleDirection === 'down';
 
         const tl = gsap.timeline({
           smoothChildTiming: true,
@@ -240,7 +276,11 @@ const Shuffle: React.FC<ShuffleProps> = ({
           repeatDelay: loop ? loopDelay : 0,
           onRepeat: () => {
             if (scrambleCharset) randomizeScrambles();
-            gsap.set(strips, { x: (i, t: HTMLElement) => parseFloat(t.getAttribute('data-start-x') || '0') });
+            if (isVertical) {
+              gsap.set(strips, { y: (i, t: HTMLElement) => parseFloat(t.getAttribute('data-start-y') || '0') });
+            } else {
+              gsap.set(strips, { x: (i, t: HTMLElement) => parseFloat(t.getAttribute('data-start-x') || '0') });
+            }
             onShuffleComplete?.();
           },
           onComplete: () => {
@@ -255,17 +295,20 @@ const Shuffle: React.FC<ShuffleProps> = ({
         });
 
         const addTween = (targets: HTMLElement[], at: number) => {
-          tl.to(
-            targets,
-            {
-              x: (i, t: HTMLElement) => parseFloat(t.getAttribute('data-final-x') || '0'),
-              duration,
-              ease,
-              force3D: true,
-              stagger: animationMode === 'evenodd' ? stagger : 0
-            },
-            at
-          );
+          const vars: any = {
+            duration,
+            ease,
+            force3D: true,
+            stagger: animationMode === 'evenodd' ? stagger : 0
+          };
+          if (isVertical) {
+            vars.y = (i: number, t: HTMLElement) => parseFloat(t.getAttribute('data-final-y') || '0');
+          } else {
+            vars.x = (i: number, t: HTMLElement) => parseFloat(t.getAttribute('data-final-x') || '0');
+          }
+
+          tl.to(targets, vars, at);
+
           if (colorFrom && colorTo) {
             tl.to(targets, { color: colorTo, duration, ease }, at);
           }
@@ -281,16 +324,17 @@ const Shuffle: React.FC<ShuffleProps> = ({
         } else {
           strips.forEach(strip => {
             const d = Math.random() * maxDelay;
-            tl.to(
-              strip,
-              {
-                x: parseFloat(strip.getAttribute('data-final-x') || '0'),
-                duration,
-                ease,
-                force3D: true
-              },
-              d
-            );
+            const vars: any = {
+              duration,
+              ease,
+              force3D: true
+            };
+            if (isVertical) {
+              vars.y = parseFloat(strip.getAttribute('data-final-y') || '0');
+            } else {
+              vars.x = parseFloat(strip.getAttribute('data-final-x') || '0');
+            }
+            tl.to(strip, vars, d);
             if (colorFrom && colorTo) tl.fromTo(strip, { color: colorFrom }, { color: colorTo, duration, ease }, d);
           });
         }

--- a/src/ts-tailwind/TextAnimations/Shuffle/Shuffle.tsx
+++ b/src/ts-tailwind/TextAnimations/Shuffle/Shuffle.tsx
@@ -11,7 +11,7 @@ export interface ShuffleProps {
   text: string;
   className?: string;
   style?: React.CSSProperties;
-  shuffleDirection?: 'left' | 'right';
+  shuffleDirection?: 'left' | 'right' | 'up' | 'down';
   duration?: number;
   maxDelay?: number;
   ease?: string | ((t: number) => number);
@@ -147,54 +147,85 @@ const Shuffle: React.FC<ShuffleProps> = ({
           if (!parent) return;
 
           const w = ch.getBoundingClientRect().width;
+          const h = ch.getBoundingClientRect().height;
           if (!w) return;
 
           const wrap = document.createElement('span');
-          wrap.className = 'inline-block overflow-hidden align-baseline text-left';
-          Object.assign(wrap.style, { width: w + 'px' });
+          wrap.className = 'inline-block overflow-hidden text-left';
+          Object.assign(wrap.style, {
+            width: w + 'px',
+            height: shuffleDirection === 'up' || shuffleDirection === 'down' ? h + 'px' : 'auto',
+            verticalAlign: 'bottom'
+          });
 
           const inner = document.createElement('span');
-          inner.className = 'inline-block whitespace-nowrap will-change-transform origin-left transform-gpu';
+          inner.className =
+            'inline-block will-change-transform origin-left transform-gpu ' +
+            (shuffleDirection === 'up' || shuffleDirection === 'down' ? 'whitespace-normal' : 'whitespace-nowrap');
 
           parent.insertBefore(wrap, ch);
           wrap.appendChild(inner);
 
           const firstOrig = ch.cloneNode(true) as HTMLElement;
-          firstOrig.className = 'inline-block text-left';
+          firstOrig.className =
+            'text-left ' + (shuffleDirection === 'up' || shuffleDirection === 'down' ? 'block' : 'inline-block');
           Object.assign(firstOrig.style, { width: w + 'px', fontFamily: computedFont });
 
           ch.setAttribute('data-orig', '1');
-          ch.className = 'inline-block text-left';
+          ch.className =
+            'text-left ' + (shuffleDirection === 'up' || shuffleDirection === 'down' ? 'block' : 'inline-block');
           Object.assign(ch.style, { width: w + 'px', fontFamily: computedFont });
 
           inner.appendChild(firstOrig);
           for (let k = 0; k < rolls; k++) {
             const c = ch.cloneNode(true) as HTMLElement;
             if (scrambleCharset) c.textContent = rand(scrambleCharset);
-            c.className = 'inline-block text-left';
+            c.className =
+              'text-left ' + (shuffleDirection === 'up' || shuffleDirection === 'down' ? 'block' : 'inline-block');
             Object.assign(c.style, { width: w + 'px', fontFamily: computedFont });
             inner.appendChild(c);
           }
           inner.appendChild(ch);
 
           const steps = rolls + 1;
-          let startX = 0;
-          let finalX = -steps * w;
-          if (shuffleDirection === 'right') {
+
+          if (shuffleDirection === 'right' || shuffleDirection === 'down') {
             const firstCopy = inner.firstElementChild as HTMLElement | null;
             const real = inner.lastElementChild as HTMLElement | null;
             if (real) inner.insertBefore(real, inner.firstChild);
             if (firstCopy) inner.appendChild(firstCopy);
-            startX = -steps * w;
-            finalX = 0;
           }
 
-          gsap.set(inner, { x: startX, force3D: true });
+          let startX = 0;
+          let finalX = 0;
+          let startY = 0;
+          let finalY = 0;
+
+          if (shuffleDirection === 'right') {
+            startX = -steps * w;
+            finalX = 0;
+          } else if (shuffleDirection === 'left') {
+            startX = 0;
+            finalX = -steps * w;
+          } else if (shuffleDirection === 'down') {
+            startY = -steps * h;
+            finalY = 0;
+          } else if (shuffleDirection === 'up') {
+            startY = 0;
+            finalY = -steps * h;
+          }
+
+          if (shuffleDirection === 'left' || shuffleDirection === 'right') {
+            gsap.set(inner, { x: startX, y: 0, force3D: true });
+            inner.setAttribute('data-start-x', String(startX));
+            inner.setAttribute('data-final-x', String(finalX));
+          } else {
+            gsap.set(inner, { x: 0, y: startY, force3D: true });
+            inner.setAttribute('data-start-y', String(startY));
+            inner.setAttribute('data-final-y', String(finalY));
+          }
+
           if (colorFrom) (inner.style as any).color = colorFrom;
-
-          inner.setAttribute('data-final-x', String(finalX));
-          inner.setAttribute('data-start-x', String(startX));
-
           wrappersRef.current.push(wrap);
         });
       };
@@ -230,6 +261,7 @@ const Shuffle: React.FC<ShuffleProps> = ({
         if (!strips.length) return;
 
         playingRef.current = true;
+        const isVertical = shuffleDirection === 'up' || shuffleDirection === 'down';
 
         const tl = gsap.timeline({
           smoothChildTiming: true,
@@ -237,7 +269,11 @@ const Shuffle: React.FC<ShuffleProps> = ({
           repeatDelay: loop ? loopDelay : 0,
           onRepeat: () => {
             if (scrambleCharset) randomizeScrambles();
-            gsap.set(strips, { x: (i, t: HTMLElement) => parseFloat(t.getAttribute('data-start-x') || '0') });
+            if (isVertical) {
+              gsap.set(strips, { y: (i, t: HTMLElement) => parseFloat(t.getAttribute('data-start-y') || '0') });
+            } else {
+              gsap.set(strips, { x: (i, t: HTMLElement) => parseFloat(t.getAttribute('data-start-x') || '0') });
+            }
             onShuffleComplete?.();
           },
           onComplete: () => {
@@ -252,17 +288,20 @@ const Shuffle: React.FC<ShuffleProps> = ({
         });
 
         const addTween = (targets: HTMLElement[], at: number) => {
-          tl.to(
-            targets,
-            {
-              x: (i, t: HTMLElement) => parseFloat(t.getAttribute('data-final-x') || '0'),
-              duration,
-              ease,
-              force3D: true,
-              stagger: animationMode === 'evenodd' ? stagger : 0
-            },
-            at
-          );
+          const vars: any = {
+            duration,
+            ease,
+            force3D: true,
+            stagger: animationMode === 'evenodd' ? stagger : 0
+          };
+          if (isVertical) {
+            vars.y = (i: number, t: HTMLElement) => parseFloat(t.getAttribute('data-final-y') || '0');
+          } else {
+            vars.x = (i: number, t: HTMLElement) => parseFloat(t.getAttribute('data-final-x') || '0');
+          }
+
+          tl.to(targets, vars, at);
+
           if (colorFrom && colorTo) tl.to(targets, { color: colorTo, duration, ease }, at);
         };
 
@@ -276,16 +315,17 @@ const Shuffle: React.FC<ShuffleProps> = ({
         } else {
           strips.forEach(strip => {
             const d = Math.random() * maxDelay;
-            tl.to(
-              strip,
-              {
-                x: parseFloat(strip.getAttribute('data-final-x') || '0'),
-                duration,
-                ease,
-                force3D: true
-              },
-              d
-            );
+            const vars: any = {
+              duration,
+              ease,
+              force3D: true
+            };
+            if (isVertical) {
+              vars.y = parseFloat(strip.getAttribute('data-final-y') || '0');
+            } else {
+              vars.x = parseFloat(strip.getAttribute('data-final-x') || '0');
+            }
+            tl.to(strip, vars, d);
             if (colorFrom && colorTo) tl.fromTo(strip, { color: colorFrom }, { color: colorTo, duration, ease }, d);
           });
         }


### PR DESCRIPTION
Added support for the `up` and `down` shuffle direction

Feature as mentioned in issue: https://github.com/DavidHDev/react-bits/issues/823

<img width="1876" height="1160" alt="image" src="https://github.com/user-attachments/assets/186b3aee-cb82-4136-ac3a-26d9385f55cd" />
