### PR TITLE
fix: remove transition delay on magnetism effect

### DIFF
--- a/src/tailwind/Components/MagicBento/MagicBento.jsx
+++ b/src/tailwind/Components/MagicBento/MagicBento.jsx
@@ -633,7 +633,7 @@ const MagicBento = ({
       <BentoCardGrid gridRef={gridRef}>
         <div className="card-responsive grid gap-2">
           {cardData.map((card, index) => {
-            const baseClassName = `card flex flex-col justify-between relative aspect-[4/3] min-h-[200px] w-full max-w-full p-5 rounded-[20px] border border-solid font-light overflow-hidden transition-all duration-300 ease-in-out hover:-translate-y-0.5 hover:shadow-[0_8px_25px_rgba(0,0,0,0.15)] ${
+            const baseClassName = `card flex flex-col justify-between relative aspect-[4/3] min-h-[200px] w-full max-w-full p-5 rounded-[20px] border border-solid font-light overflow-hidden transition-colors duration-300 ease-in-out hover:-translate-y-0.5 hover:shadow-[0_8px_25px_rgba(0,0,0,0.15)] ${
               enableBorderGlow ? 'card--border-glow' : ''
             }`;
 

--- a/src/ts-tailwind/Components/MagicBento/MagicBento.tsx
+++ b/src/ts-tailwind/Components/MagicBento/MagicBento.tsx
@@ -675,7 +675,7 @@ const MagicBento: React.FC<BentoProps> = ({
       <BentoCardGrid gridRef={gridRef}>
         <div className="card-responsive grid gap-2">
           {cardData.map((card, index) => {
-            const baseClassName = `card flex flex-col justify-between relative aspect-[4/3] min-h-[200px] w-full max-w-full p-5 rounded-[20px] border border-solid font-light overflow-hidden transition-all duration-300 ease-in-out hover:-translate-y-0.5 hover:shadow-[0_8px_25px_rgba(0,0,0,0.15)] ${
+            const baseClassName = `card flex flex-col justify-between relative aspect-[4/3] min-h-[200px] w-full max-w-full p-5 rounded-[20px] border border-solid font-light overflow-hidden transition-colors duration-300 ease-in-out hover:-translate-y-0.5 hover:shadow-[0_8px_25px_rgba(0,0,0,0.15)] ${
               enableBorderGlow ? 'card--border-glow' : ''
             }`;
 


### PR DESCRIPTION
Fixes #850

Changed `transition-all` to `transition-colors` to prevent CSS transitions from interfering with GSAP transform animations when `enableMagnetism` or `enableTilt` are enabled.

## Changes
- Updated the `baseClassName` CSS classes to use `transition-colors` instead of `transition-all`
- This allows GSAP to control transform animations without the 300ms CSS transition delay
- Color-related properties (borders, shadows) still animate smoothly with CSS transitions

## Testing
- Tested with `enableMagnetism={true}` - cards now follow cursor immediately without delay
- Tested with `enableTilt={true}` - tilt effect is now smooth and responsive
- Verified that hover effects (shadows, translate) still work as expected
---
Contributed by [Rahul Kumar Mall](https://rahul-kumar-mall.vercel.app)