### PR TITLE
fix(SplitText): resolve hydration mismatch by supporting dynamic tags

### DIFF
--- a/src/content/TextAnimations/SplitText/SplitText.jsx
+++ b/src/content/TextAnimations/SplitText/SplitText.jsx
@@ -155,50 +155,13 @@ const SplitText = ({
       willChange: 'transform, opacity'
     };
     const classes = `split-parent ${className}`;
-    switch (tag) {
-      case 'h1':
-        return (
-          <h1 ref={ref} style={style} className={classes}>
-            {text}
-          </h1>
-        );
-      case 'h2':
-        return (
-          <h2 ref={ref} style={style} className={classes}>
-            {text}
-          </h2>
-        );
-      case 'h3':
-        return (
-          <h3 ref={ref} style={style} className={classes}>
-            {text}
-          </h3>
-        );
-      case 'h4':
-        return (
-          <h4 ref={ref} style={style} className={classes}>
-            {text}
-          </h4>
-        );
-      case 'h5':
-        return (
-          <h5 ref={ref} style={style} className={classes}>
-            {text}
-          </h5>
-        );
-      case 'h6':
-        return (
-          <h6 ref={ref} style={style} className={classes}>
-            {text}
-          </h6>
-        );
-      default:
-        return (
-          <p ref={ref} style={style} className={classes}>
-            {text}
-          </p>
-        );
-    }
+    const Tag = (tag || 'p');
+
+    return (
+      <Tag ref={ref} style={style} className={classes}>
+        {text}
+      </Tag>
+    );
   };
   return renderTag();
 };

--- a/src/tailwind/TextAnimations/SplitText/SplitText.jsx
+++ b/src/tailwind/TextAnimations/SplitText/SplitText.jsx
@@ -150,50 +150,13 @@ const SplitText = ({
       willChange: 'transform, opacity'
     };
     const classes = `split-parent overflow-hidden inline-block whitespace-normal ${className}`;
-    switch (tag) {
-      case 'h1':
-        return (
-          <h1 ref={ref} style={style} className={classes}>
-            {text}
-          </h1>
-        );
-      case 'h2':
-        return (
-          <h2 ref={ref} style={style} className={classes}>
-            {text}
-          </h2>
-        );
-      case 'h3':
-        return (
-          <h3 ref={ref} style={style} className={classes}>
-            {text}
-          </h3>
-        );
-      case 'h4':
-        return (
-          <h4 ref={ref} style={style} className={classes}>
-            {text}
-          </h4>
-        );
-      case 'h5':
-        return (
-          <h5 ref={ref} style={style} className={classes}>
-            {text}
-          </h5>
-        );
-      case 'h6':
-        return (
-          <h6 ref={ref} style={style} className={classes}>
-            {text}
-          </h6>
-        );
-      default:
-        return (
-          <p ref={ref} style={style} className={classes}>
-            {text}
-          </p>
-        );
-    }
+    const Tag = (tag || 'p');
+
+    return (
+      <Tag ref={ref} style={style} className={classes}>
+        {text}
+      </Tag>
+    );
   };
   return renderTag();
 };

--- a/src/ts-default/TextAnimations/SplitText/SplitText.tsx
+++ b/src/ts-default/TextAnimations/SplitText/SplitText.tsx
@@ -165,50 +165,13 @@ const SplitText: React.FC<SplitTextProps> = ({
       willChange: 'transform, opacity'
     };
     const classes = `split-parent ${className}`;
-    switch (tag) {
-      case 'h1':
-        return (
-          <h1 ref={ref} style={style} className={classes}>
-            {text}
-          </h1>
-        );
-      case 'h2':
-        return (
-          <h2 ref={ref} style={style} className={classes}>
-            {text}
-          </h2>
-        );
-      case 'h3':
-        return (
-          <h3 ref={ref} style={style} className={classes}>
-            {text}
-          </h3>
-        );
-      case 'h4':
-        return (
-          <h4 ref={ref} style={style} className={classes}>
-            {text}
-          </h4>
-        );
-      case 'h5':
-        return (
-          <h5 ref={ref} style={style} className={classes}>
-            {text}
-          </h5>
-        );
-      case 'h6':
-        return (
-          <h6 ref={ref} style={style} className={classes}>
-            {text}
-          </h6>
-        );
-      default:
-        return (
-          <p ref={ref} style={style} className={classes}>
-            {text}
-          </p>
-        );
-    }
+    const Tag = (tag || 'p') as React.ElementType;
+
+    return (
+      <Tag ref={ref} style={style} className={classes}>
+        {text}
+      </Tag>
+    );
   };
   return renderTag();
 };

--- a/src/ts-tailwind/TextAnimations/SplitText/SplitText.tsx
+++ b/src/ts-tailwind/TextAnimations/SplitText/SplitText.tsx
@@ -155,6 +155,7 @@ const SplitText: React.FC<SplitTextProps> = ({
     }
   );
 
+  
   const renderTag = () => {
     const style: React.CSSProperties = {
       textAlign,
@@ -162,51 +163,16 @@ const SplitText: React.FC<SplitTextProps> = ({
       willChange: 'transform, opacity'
     };
     const classes = `split-parent overflow-hidden inline-block whitespace-normal ${className}`;
-    switch (tag) {
-      case 'h1':
-        return (
-          <h1 ref={ref} style={style} className={classes}>
-            {text}
-          </h1>
-        );
-      case 'h2':
-        return (
-          <h2 ref={ref} style={style} className={classes}>
-            {text}
-          </h2>
-        );
-      case 'h3':
-        return (
-          <h3 ref={ref} style={style} className={classes}>
-            {text}
-          </h3>
-        );
-      case 'h4':
-        return (
-          <h4 ref={ref} style={style} className={classes}>
-            {text}
-          </h4>
-        );
-      case 'h5':
-        return (
-          <h5 ref={ref} style={style} className={classes}>
-            {text}
-          </h5>
-        );
-      case 'h6':
-        return (
-          <h6 ref={ref} style={style} className={classes}>
-            {text}
-          </h6>
-        );
-      default:
-        return (
-          <p ref={ref} style={style} className={classes}>
-            {text}
-          </p>
-        );
-    }
+    const Tag = (tag || 'p') as React.ElementType;
+
+    return (
+      <Tag ref={ref} style={style} className={classes}>
+        {text}
+      </Tag>
+    );
   };
+
+  
 
   return renderTag();
 };


### PR DESCRIPTION
close #857 

###  Description
This PR addresses a **Hydration Mismatch Error** that occurs when the `SplitText` component is nested inside a parent `<p>` tag (e.g., `<p cannot be a descendant of <p>`).

Previously, the component relied on a hardcoded `switch` statement that defaulted to rendering a `<p>` tag, making it impossible to satisfy HTML nesting rules even when a user wanted to render it as a `span`.

###  Changes
I have refactored the `renderTag` function to support **Dynamic Tag Rendering** (Polymorphic Component Pattern).

1.  **Removed the verbose `switch` statement**: Replaced it with a direct assignment (`const Tag = tag;`).
2.  **Type Safety**: Since the `tag` prop is typed as a strict Union Type (`'h1' | ... | 'span' | 'p'`), there is no risk of invalid or unsafe HTML tags being rendered.
3.  **Default Behavior**: It continues to default to `'p'` (via default props), preserving backward compatibility.

###  Code Comparison
**Before (Rigid Switch Case):**
```tsx
switch (tag) {
  case 'h1': return <h1 ...>{text}</h1>;
  // ... repeated code ...
  default: return <p ...>{text}</p>;
}
```

**After (Dynamic & Type-Safe):**

```tsx
const renderTag = () => {
  // ... styles ...
  
  // The 'tag' prop is already type-checked (Union Type), so it's safe to use directly.
  const Tag = tag; 

  return (
    <Tag ref={ref} style={style} className={classes}>
      {text}
    </Tag>
  );
};
```
