### PR TITLE
chore: bump jsrepo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "three": "^0.167.1"
       },
       "devDependencies": {
-        "@jsrepo/shadcn": "^0.0.1",
+        "@jsrepo/shadcn": "^2.0.0",
         "@types/matter-js": "^0.19.8",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
@@ -59,7 +59,7 @@
         "eslint-plugin-react": "^7.34.3",
         "eslint-plugin-react-hooks": "^4.6.2",
         "eslint-plugin-react-refresh": "^0.4.7",
-        "jsrepo": "^3.0.0",
+        "jsrepo": "^3.2.0",
         "postcss-safe-parser": "^7.0.1",
         "prettier": "^3.6.2",
         "tw-animate-css": "^1.4.0",
@@ -465,9 +465,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@emnapi/core": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.5.0.tgz",
-      "integrity": "sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
+      "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -476,9 +476,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
-      "integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
+      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1198,13 +1198,13 @@
       }
     },
     "node_modules/@jsrepo/shadcn": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@jsrepo/shadcn/-/shadcn-0.0.1.tgz",
-      "integrity": "sha512-pzefKC8HNLXPkbmPziIdjORwt0eu8/uTtuX6iSolckuo5hysRKWlvmwu2UnLf+sBlBKpr3lE2XKh1kUuwkj6qw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@jsrepo/shadcn/-/shadcn-2.0.0.tgz",
+      "integrity": "sha512-qodQu5aiSGvL4gvtKa5oaARCQrVD+5VwxRraCT+UeV8cq1LrrAWqV0DHkV7WguJqSwWo9Lp8LsqgoeI4GAZStg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "jsrepo": "3.0.0"
+        "jsrepo": "3.2.0"
       }
     },
     "node_modules/@mediapipe/tasks-vision": {
@@ -1275,10 +1275,27 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@oxc-parser/binding-android-arm-eabi": {
+      "version": "0.107.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.107.0.tgz",
+      "integrity": "sha512-Fhap02+E3+tBDLsBZcsr7289kCfR3hyQnBAjhi7RSTHc7Ikydh1hS5cIzjOtlidFZJ1Vz5edbfoKGWO3/DqJNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@oxc-parser/binding-android-arm64": {
-      "version": "0.96.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.96.0.tgz",
-      "integrity": "sha512-CofbPOiW1PG+hi8bgElJPK0ioHfw8nt4Vw9d+Q9JuMhygS6LbQyu1W6tIFZ1OPFofeFRdWus3vD29FBx+tvFOA==",
+      "version": "0.107.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.107.0.tgz",
+      "integrity": "sha512-3gXyxBdwNzOCSdbzN3FSncilXUe/OJP0SAovRz+e20q5FInUYfVvOZUJfpII01anSmg+7KWY7p69IAgDYZZepw==",
       "cpu": [
         "arm64"
       ],
@@ -1293,9 +1310,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-darwin-arm64": {
-      "version": "0.96.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.96.0.tgz",
-      "integrity": "sha512-+HZ2L1a/1BsUXYik8XqQwT2Tl5Z3jRQ/RRQiPV9UsB2skKyd91NLDlQlMpdhjLGs9Qe7Y42unFjRg2iHjIiwnw==",
+      "version": "0.107.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.107.0.tgz",
+      "integrity": "sha512-i8W2krLmBd6jWldW1Y4/12zke+euEYZGuUggijJhEFy5xTQbwOhgVDWpdUx3CgZ17Plzjkd/dB/Ga0b13i0kAg==",
       "cpu": [
         "arm64"
       ],
@@ -1310,9 +1327,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-darwin-x64": {
-      "version": "0.96.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.96.0.tgz",
-      "integrity": "sha512-GC8wH1W0XaCLyTeGsmyaMdnItiYQkqfTcn9Ygc55AWI+m11lCjQeoKDIsDCm/QwrKLCN07u3WWWsuPs5ubfXpA==",
+      "version": "0.107.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.107.0.tgz",
+      "integrity": "sha512-JwDxozL+IPXeiP57GyRmC3coIKR7Duit69aHvhf63NZqMClnglI0gR8mI+JH4lNBP/o6AGaY22+8/rlfiMW5Pg==",
       "cpu": [
         "x64"
       ],
@@ -1327,9 +1344,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-freebsd-x64": {
-      "version": "0.96.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.96.0.tgz",
-      "integrity": "sha512-8SeXi2FmlN15uPY5oM03cua5RXBDYmY34Uewongv6RUiAaU/kWxLvzuijpyNC+yQ1r4fC2LbWJhAsKpX5qkA6g==",
+      "version": "0.107.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.107.0.tgz",
+      "integrity": "sha512-m8h7qkymDLqxRGARWPJQH9x/I4ZLlwMhigj9iVkKZ7db/J1wl9ha+a9DCBrm5kRYikl4dSwu7wZXykKmrOzVVA==",
       "cpu": [
         "x64"
       ],
@@ -1344,9 +1361,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
-      "version": "0.96.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.96.0.tgz",
-      "integrity": "sha512-UEs+Zf6T2/FwQlLgv7gfZsKmY19sl3hK57r2BQVc2eCmCmF/deeqDcWyFjzkNLgdDDucY60PoNhNGClDm605uQ==",
+      "version": "0.107.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.107.0.tgz",
+      "integrity": "sha512-QI9b9BvWcIk/vuBUGgas4eZZCXikd7yfXTppIFM2hNZN+omd2nCDMGZ5yMHy1r+TJw1hdxei8f8xzwmO1nTq3A==",
       "cpu": [
         "arm"
       ],
@@ -1361,9 +1378,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
-      "version": "0.96.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.96.0.tgz",
-      "integrity": "sha512-1kuWvjR2+ORJMoyxt9LSbLcDhXZnL25XOuv9VmH6NmSPvLgewzuubSlm++W03x+U7SzWFilBsdwIHtD/0mjERw==",
+      "version": "0.107.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.107.0.tgz",
+      "integrity": "sha512-VMoeP+VZegiqRqcUa0RzopOErELVTSNDfdVIX/8No3ieZdxdHqvGlBmdCqqxIYZEYif2IZJ3VcIr2RvX4y8k9w==",
       "cpu": [
         "arm"
       ],
@@ -1378,9 +1395,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
-      "version": "0.96.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.96.0.tgz",
-      "integrity": "sha512-PHH4ETR1t0fymxuhpQNj3Z9t/78/zZa2Lj3Z3I0ZOd+/Ex+gtdhGoB5xYyy7lcYGAPMfZ+Gmr+dTCr1GYNZ3BA==",
+      "version": "0.107.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.107.0.tgz",
+      "integrity": "sha512-01yvXlhCB8aCu9xftIQCI9TGvVb2+md4ULJYmDSil4Qr4XfXa8soEJxfS/ywe+RiDnW7w8qomtz0DI+HT5sHRw==",
       "cpu": [
         "arm64"
       ],
@@ -1395,9 +1412,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm64-musl": {
-      "version": "0.96.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.96.0.tgz",
-      "integrity": "sha512-fjDPbZjkqaDSTBe0FM8nZ9zBw4B/NF/I0gH7CfvNDwIj9smISaNFypYeomkvubORpnbX9ORhvhYwg3TxQ60OGA==",
+      "version": "0.107.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.107.0.tgz",
+      "integrity": "sha512-pp2ovq2qxqGTyRclBe65/VD3IL0fwT+X5XJSKhdhO94BtNOPCcW0bZAgG3ILkoWPPdmtWUXT/y59cCkK+QNEYg==",
       "cpu": [
         "arm64"
       ],
@@ -1411,10 +1428,44 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+      "version": "0.107.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.107.0.tgz",
+      "integrity": "sha512-1AgcnFazS00KBq38eQ8EW/vwjgtcNvVdbR/SnteVDY4j0klgSxaYe2/CQXnww4wVh8UjE3IHYYAfsudhggET0Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
-      "version": "0.96.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.96.0.tgz",
-      "integrity": "sha512-59KAHd/6/LmjkdSAuJn0piKmwSavMasWNUKuYLX/UnqI5KkGIp14+LBwwaBG6KzOtIq1NrRCnmlL4XSEaNkzTg==",
+      "version": "0.107.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.107.0.tgz",
+      "integrity": "sha512-Yg/YyeaV9RiStZG2Rc50xhzrBIG2w1PuKJjlbVtJ+Mb2kY0zxhg2Pnifjt85ZKJqqJ9Bfao1LVXNweV2HYRAJA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+      "version": "0.107.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.107.0.tgz",
+      "integrity": "sha512-/KGiC2Ko1k0rQxTYqTP1MDipV5LCw5by9Yx+qUy5LL0eHtI06CkIZ9mPMua5+hwLygwMrv7Ry8MjpeTQ0qHpcQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1429,9 +1480,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
-      "version": "0.96.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.96.0.tgz",
-      "integrity": "sha512-VtupojtgahY8XmLwpVpM3C1WQEgMD1JxpB8lzUtdSLwosWaaz1EAl+VXWNuxTTZusNuLBtmR+F0qql22ISi/9g==",
+      "version": "0.107.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.107.0.tgz",
+      "integrity": "sha512-F4UKJ19+vTHTA7miSt7DWG04NwMGbLj4C7BfWY8V3LMX5zp68py/rcKYBusC7hcJQ4YBUKQzl1WLx9PMzyWiXg==",
       "cpu": [
         "s390x"
       ],
@@ -1446,9 +1497,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-x64-gnu": {
-      "version": "0.96.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.96.0.tgz",
-      "integrity": "sha512-8XSY9aUYY+5I4I1mhSEWmYqdUrJi3J5cCAInvEVHyTnDAPkhb+tnLGVZD696TpW+lFOLrTFF2V5GMWJVafqIUA==",
+      "version": "0.107.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.107.0.tgz",
+      "integrity": "sha512-vF4vemHhzCsKQhfaV/j7xS7AavMVkHy29zhlAE03r61lvKK4lQBr2VvT6qgSTn4eYGNEHEZbRoFNOcmtaPGjtA==",
       "cpu": [
         "x64"
       ],
@@ -1463,9 +1514,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-x64-musl": {
-      "version": "0.96.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.96.0.tgz",
-      "integrity": "sha512-IIVNtqhA0uxKkD8Y6aZinKO/sOD5O62VlduE54FnUU2rzZEszrZQLL8nMGVZhTdPaKW5M1aeLmjcdnOs6er1Jg==",
+      "version": "0.107.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.107.0.tgz",
+      "integrity": "sha512-p6jxLjIMiySYclrRuVQELSm6wT5lTfkPRmcZKbtmLhyMlAR2rhuILnoZ/iVoE3Ib/hpE4G6XkLhRZLvp6ZVazw==",
       "cpu": [
         "x64"
       ],
@@ -1479,10 +1530,27 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@oxc-parser/binding-openharmony-arm64": {
+      "version": "0.107.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.107.0.tgz",
+      "integrity": "sha512-iCUiKTYwqSmA/qgBR300fmXLVVi9tmk43O2B4oeMaydvnqUNWmZTNciOPwAFfc6024ISxZ77y4ISHTE0plX3LQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@oxc-parser/binding-wasm32-wasi": {
-      "version": "0.96.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.96.0.tgz",
-      "integrity": "sha512-TJ/sNPbVD4u6kUwm7sDKa5iRDEB8vd7ZIMjYqFrrAo9US1RGYOSvt6Ie9sDRekUL9fZhNsykvSrpmIj6dg/C2w==",
+      "version": "0.107.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.107.0.tgz",
+      "integrity": "sha512-VxrwctWEUSI3eJkRAGHISNlikcx8xAoglvAYAW4cdC5HfXbwRMuEunzzXMNXpNUMrdlqjf25Ay6OaxaztAOKgQ==",
       "cpu": [
         "wasm32"
       ],
@@ -1490,29 +1558,33 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.0.7"
+        "@napi-rs/wasm-runtime": "^1.1.1"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.0.7.tgz",
-      "integrity": "sha512-SeDnOO0Tk7Okiq6DbXmmBODgOAb9dp9gjlphokTUxmt8U3liIP1ZsozBahH69j/RJv+Rfs6IwUKHTgQYJ/HBAw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
+      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.5.0",
-        "@emnapi/runtime": "^1.5.0",
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
         "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
     "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
-      "version": "0.96.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.96.0.tgz",
-      "integrity": "sha512-zCOhRB7MYVIHLj+2QYoTuLyaipiD8JG/ggUjfsMUaupRPpvwQNhsxINLIcTcb0AS+OsT7/OREhydjO74STqQzQ==",
+      "version": "0.107.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.107.0.tgz",
+      "integrity": "sha512-zJlOsumV4JpUs0PGMF0ycjfCcV91Tpr81N7Qn5O00+MjFxI3AlHmrkhYTFA2cFicUW6XXSPe6KvEG8v46BCIBA==",
       "cpu": [
         "arm64"
       ],
@@ -1526,10 +1598,27 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+      "version": "0.107.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.107.0.tgz",
+      "integrity": "sha512-vH44IYIiqzAxq7la/O+IRNdB3XqgdMRjVVT1UqA4rmyHUEQcfmCYy6cbbP07m5eLY2xAHAmuDqxBJEnQDGGGJQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@oxc-parser/binding-win32-x64-msvc": {
-      "version": "0.96.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.96.0.tgz",
-      "integrity": "sha512-J6zfx9TE0oS+TrqBUjMVMOi/d/j3HMj69Pip263pETOEPm788N0HXKPsc2X2jUfSTHzD9vmdjq0QFymbf2LhWg==",
+      "version": "0.107.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.107.0.tgz",
+      "integrity": "sha512-8x6u+nIKEFR3WT5oHhSP7oPZGI8VLq3iVxOEeV75NfB5ubGUA7sNHcssZ37jmUfhYnkYzBiCGhEAIRa9bUMzBw==",
       "cpu": [
         "x64"
       ],
@@ -1544,9 +1633,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.96.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.96.0.tgz",
-      "integrity": "sha512-r/xkmoXA0xEpU6UGtn18CNVjXH6erU3KCpCDbpLmbVxBFor1U9MqN5Z2uMmCHJuXjJzlnDR+hWY+yPoLo8oHDw==",
+      "version": "0.107.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.107.0.tgz",
+      "integrity": "sha512-QFDRbYfV2LVx8tyqtyiah3jQPUj1mK2+RYwxyFWyGoys6XJnwTdlzO6rdNNHOPorHAu5Uo34oWRKcvNpbJarmQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1559,13 +1648,13 @@
       "integrity": "sha512-UhRgg1k9VKRCBAHl+XUK3lvN0k9bYifzYGZOqajDid4L1DyU813A1L0ZwN4iV9WX5TX3PfUugqtgG9LnIeFGBQ=="
     },
     "node_modules/@quansync/fs": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@quansync/fs/-/fs-0.1.5.tgz",
-      "integrity": "sha512-lNS9hL2aS2NZgNW7BBj+6EBl4rOf8l+tQ0eRY6JWCI8jI2kc53gSoqbjojU0OnAWhzoXiOjFyGsHcDGePB3lhA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@quansync/fs/-/fs-1.0.0.tgz",
+      "integrity": "sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "quansync": "^0.2.11"
+        "quansync": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sxzz"
@@ -6115,18 +6204,18 @@
       }
     },
     "node_modules/jsrepo": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/jsrepo/-/jsrepo-3.0.0.tgz",
-      "integrity": "sha512-srEQnDRcryOHNwt15aZKgQ/rdNoKowlv+i7t7ok/5DesrBppJozrLCIu4oYSUtl8hoI+hvSRsl82MFstKYrUDg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsrepo/-/jsrepo-3.2.0.tgz",
+      "integrity": "sha512-bYJKkUj+byO06r+3PrUY5rd1tZ+Nb3EY4zBlItAw071Gk/Yr9CCF/roKtxXrWt/I8WV5lq/Tm/GJNugU+vXbNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.2",
-        "oxc-parser": "^0.96.0",
-        "unconfig": "^7.3.3"
+        "oxc-parser": "^0.107.0",
+        "unconfig": "^7.4.2"
       },
       "bin": {
-        "jsrepo": "dist/bin.js"
+        "jsrepo": "dist/bin.mjs"
       },
       "peerDependencies": {
         "svelte": "^5.0.0",
@@ -6930,13 +7019,13 @@
       }
     },
     "node_modules/oxc-parser": {
-      "version": "0.96.0",
-      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.96.0.tgz",
-      "integrity": "sha512-ucs6niJ5mZlYP3oTl4AK2eD2m7WLoSaljswnSFVYWrXzme5PtM97S7Ve1Tjx+/TKjanmEZuSt1f1qYi6SZvntw==",
+      "version": "0.107.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.107.0.tgz",
+      "integrity": "sha512-3HuDitM2UIEDbCjEhXyLAC8LuQvneDq/0eioczXZFeY4f4ee91tUcavZ9U7s4ZIFZOoHmNtOyOCB6kOM4OAtOA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "^0.96.0"
+        "@oxc-project/types": "^0.107.0"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
@@ -6945,21 +7034,26 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxc-parser/binding-android-arm64": "0.96.0",
-        "@oxc-parser/binding-darwin-arm64": "0.96.0",
-        "@oxc-parser/binding-darwin-x64": "0.96.0",
-        "@oxc-parser/binding-freebsd-x64": "0.96.0",
-        "@oxc-parser/binding-linux-arm-gnueabihf": "0.96.0",
-        "@oxc-parser/binding-linux-arm-musleabihf": "0.96.0",
-        "@oxc-parser/binding-linux-arm64-gnu": "0.96.0",
-        "@oxc-parser/binding-linux-arm64-musl": "0.96.0",
-        "@oxc-parser/binding-linux-riscv64-gnu": "0.96.0",
-        "@oxc-parser/binding-linux-s390x-gnu": "0.96.0",
-        "@oxc-parser/binding-linux-x64-gnu": "0.96.0",
-        "@oxc-parser/binding-linux-x64-musl": "0.96.0",
-        "@oxc-parser/binding-wasm32-wasi": "0.96.0",
-        "@oxc-parser/binding-win32-arm64-msvc": "0.96.0",
-        "@oxc-parser/binding-win32-x64-msvc": "0.96.0"
+        "@oxc-parser/binding-android-arm-eabi": "0.107.0",
+        "@oxc-parser/binding-android-arm64": "0.107.0",
+        "@oxc-parser/binding-darwin-arm64": "0.107.0",
+        "@oxc-parser/binding-darwin-x64": "0.107.0",
+        "@oxc-parser/binding-freebsd-x64": "0.107.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.107.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.107.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.107.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.107.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.107.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.107.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.107.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.107.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.107.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.107.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.107.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.107.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.107.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.107.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.107.0"
       }
     },
     "node_modules/p-limit": {
@@ -7273,9 +7367,9 @@
       }
     },
     "node_modules/quansync": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
-      "integrity": "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/quansync/-/quansync-1.0.0.tgz",
+      "integrity": "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==",
       "dev": true,
       "funding": [
         {
@@ -8562,31 +8656,31 @@
       }
     },
     "node_modules/unconfig": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/unconfig/-/unconfig-7.4.1.tgz",
-      "integrity": "sha512-uyQ7LElcGizrOGZyIq9KU+xkuEjcRf9IpmDTkCSYv5mEeZzrXSj6rb51C0L+WTedsmAoVxW9WKrLWhSwebIM9Q==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/unconfig/-/unconfig-7.4.2.tgz",
+      "integrity": "sha512-nrMlWRQ1xdTjSnSUqvYqJzbTBFugoqHobQj58B2bc8qxHKBBHMNNsWQFP3Cd3/JZK907voM2geYPWqD4VK3MPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@quansync/fs": "^0.1.5",
+        "@quansync/fs": "^1.0.0",
         "defu": "^6.1.4",
         "jiti": "^2.6.1",
-        "quansync": "^0.2.11",
-        "unconfig-core": "7.4.1"
+        "quansync": "^1.0.0",
+        "unconfig-core": "7.4.2"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/unconfig-core": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/unconfig-core/-/unconfig-core-7.4.1.tgz",
-      "integrity": "sha512-Bp/bPZjV2Vl/fofoA2OYLSnw1Z0MOhCX7zHnVCYrazpfZvseBbGhwcNQMxsg185Mqh7VZQqK3C8hFG/Dyng+yA==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/unconfig-core/-/unconfig-core-7.4.2.tgz",
+      "integrity": "sha512-VgPCvLWugINbXvMQDf8Jh0mlbvNjNC6eSUziHsBCMpxR05OPrNrvDnyatdMjRgcHaaNsCqz+wjNXxNw1kRLHUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@quansync/fs": "^0.1.5",
-        "quansync": "^0.2.11"
+        "@quansync/fs": "^1.0.0",
+        "quansync": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "three": "^0.167.1"
   },
   "devDependencies": {
-    "@jsrepo/shadcn": "^0.0.1",
+    "@jsrepo/shadcn": "^2.0.0",
     "@types/matter-js": "^0.19.8",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
@@ -65,7 +65,7 @@
     "eslint-plugin-react": "^7.34.3",
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-react-refresh": "^0.4.7",
-    "jsrepo": "^3.0.0",
+    "jsrepo": "^3.2.0",
     "postcss-safe-parser": "^7.0.1",
     "prettier": "^3.6.2",
     "tw-animate-css": "^1.4.0",


### PR DESCRIPTION
Bumping jsrepo cause we made some changes that slightly change the way dependencies work.

TLDR; we now also resolve dependencies within items aswell. This allows us to handle files being renamed by transforms (more coming soon)

This doesn't actually effect this project though (as far as registry generation) since there aren't any items that actually have _imports_. So just updating in case you have any that do in the future.