### PR TITLE
docs(contributing): clarify branch naming for feat and fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,11 +10,16 @@ We use the GitHub issue tracker to keep track of bugs, feature requests, and oth
 
 ## Branch Naming
 
-When creating branches for your contributions, please follow the following naming convention:
+When creating branches for your contributions, please follow these naming conventions:
 
 `feat/<feature-name>`
+`fix/<bug-name>`
 
-For example, if you are working on a feature related to adding a new component, your branch name could be `feat/fix-x-component`. This naming convention helps us to easily track and associate contributions with their respective features.
+For example:
+- If you are adding a feature, use `feat/<feature-name>` (e.g. `feat/add-gradient-button`).
+- If you are fixing a bug, use `fix/<bug-name>` (e.g. `fix/decrypted-text-hover-state`).
+
+This naming convention helps us track and associate contributions with their purpose.
 
 ## Pull Requests
 


### PR DESCRIPTION
## Summary

This PR clarifies the branch naming section in `CONTRIBUTING.md` to avoid confusion that all branches should use only `feat/*`.

## Changes

- Added `fix/<bug-name>` as an explicit branch naming convention.
- Kept `feat/<feature-name>` and presented both conventions together.
- Replaced the ambiguous example with clear examples for:
  - feature branches (`feat/add-gradient-button`)
  - bug-fix branches (`fix/decrypted-text-hover-state`)
- Updated wording to explain that branch names should reflect contribution purpose.

## Verification

- Confirmed `CONTRIBUTING.md` now documents both `feat/*` and `fix/*`.
- Confirmed the updated examples are consistent with actual PR branch usage patterns in the repository.

## Scope

- Documentation only (`CONTRIBUTING.md`)
- No runtime/code behavior changes
