### PR TITLE
fix: handle SSR error in TargetCursor component by checking for window object & fixed duplicate id in sponsors constant

### DIFF
--- a/src/constants/Sponsors.js
+++ b/src/constants/Sponsors.js
@@ -7,7 +7,7 @@ export const diamondSponsors = [
     url: 'https://www.shadcnblocks.com/'
   },
   {
-    id: 1,
+    id: 2,
     name: 'shadcn studio',
     imageUrl: '/assets/sponsors/shadcnstudio.svg',
     url: 'https://shadcnstudio.com/'

--- a/src/content/Animations/TargetCursor/TargetCursor.jsx
+++ b/src/content/Animations/TargetCursor/TargetCursor.jsx
@@ -20,6 +20,7 @@ const TargetCursor = ({
   const activeStrengthRef = useRef(0);
 
   const isMobile = useMemo(() => {
+    if (typeof window === 'undefined') return false;
     const hasTouchScreen = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
     const isSmallScreen = window.innerWidth <= 768;
     const userAgent = navigator.userAgent || navigator.vendor || window.opera;

--- a/src/tailwind/Animations/TargetCursor/TargetCursor.jsx
+++ b/src/tailwind/Animations/TargetCursor/TargetCursor.jsx
@@ -19,6 +19,7 @@ const TargetCursor = ({
   const activeStrengthRef = useRef(0);
 
   const isMobile = useMemo(() => {
+    if (typeof window === 'undefined') return false;
     const hasTouchScreen = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
     const isSmallScreen = window.innerWidth <= 768;
     const userAgent = navigator.userAgent || navigator.vendor || window.opera;

--- a/src/ts-default/Animations/TargetCursor/TargetCursor.tsx
+++ b/src/ts-default/Animations/TargetCursor/TargetCursor.tsx
@@ -28,6 +28,7 @@ const TargetCursor: React.FC<TargetCursorProps> = ({
   const activeStrengthRef = useRef({ current: 0 });
 
   const isMobile = useMemo(() => {
+    if (typeof window === 'undefined') return false;
     const hasTouchScreen = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
     const isSmallScreen = window.innerWidth <= 768;
     const userAgent = navigator.userAgent || navigator.vendor || (window as any).opera;

--- a/src/ts-tailwind/Animations/TargetCursor/TargetCursor.tsx
+++ b/src/ts-tailwind/Animations/TargetCursor/TargetCursor.tsx
@@ -27,6 +27,7 @@ const TargetCursor: React.FC<TargetCursorProps> = ({
   const activeStrengthRef = useRef({ current: 0 });
 
   const isMobile = useMemo(() => {
+    if (typeof window === 'undefined') return false;
     const hasTouchScreen = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
     const isSmallScreen = window.innerWidth <= 768;
     const userAgent = navigator.userAgent || navigator.vendor || (window as any).opera;


### PR DESCRIPTION
**fix(TargetCursor): resolve SSR ReferenceError in Next.js + fix duplicate sponsor ID**

**Problem**
Two issues addressed in this PR:

1. **Server-side rendering crash in Next.js (Issue #910)**
The `TargetCursor` component evaluated the `isMobile` state inside a `useMemo` block by directly accessing `window` and `navigator`. During Server-Side Rendering (SSR) in frameworks like Next.js, the `window` object does not exist. This resulted in a fatal `ReferenceError: window is not defined` (500 error), completely breaking the build/render process before the component could reach the client.

2. **Duplicate ID in constants**
A minor data anomaly existed in `src/constants/Sponsors.js` where two sponsor entries shared the exact same ID (`id: 1`), which could lead to React key mapping warnings or rendering bugs.

**Fix**
* **TargetCursor SSR Guard:** Added an early return `if (typeof window === 'undefined') return false;` at the very top of the `isMobile` `useMemo` block. This safely bypasses the touch/screen evaluations during the server pass, deferring the actual device check to the client-side hydration phase.
* **Sponsors ID:** Incremented the duplicated `id: 1` to `id: 2` in the `Sponsors.js` file.

**Result**
The `TargetCursor` component can now be safely initialized in Next.js and other SSR environments without throwing 500 errors. The client directive (`"use client"`) will now work seamlessly without tripping over undefined global objects during the initial server pass.

* Closes #910
* All variants updated (JS-CSS, JS-TW, TS-CSS, TS-TW)
* Build passes ✓
* Not a breaking change.