### PR TITLE
fix(Counter): ensure correct number rendering in RTL by enforcing LTR…

### DIFF
--- a/src/content/Components/Counter/Counter.jsx
+++ b/src/content/Components/Counter/Counter.jsx
@@ -96,7 +96,8 @@ export default function Counter({
     paddingLeft: horizontalPadding,
     paddingRight: horizontalPadding,
     color: textColor,
-    fontWeight: fontWeight
+    fontWeight: fontWeight,
+    direction: "ltr"
   };
   const defaultTopGradientStyle = {
     height: gradientHeight,

--- a/src/tailwind/Components/Counter/Counter.jsx
+++ b/src/tailwind/Components/Counter/Counter.jsx
@@ -115,7 +115,8 @@ export default function Counter({
     paddingRight: horizontalPadding,
     lineHeight: 1,
     color: textColor,
-    fontWeight
+    fontWeight,
+    direction: "ltr"
   };
 
   const gradientContainerStyle = {

--- a/src/ts-default/Components/Counter/Counter.tsx
+++ b/src/ts-default/Components/Counter/Counter.tsx
@@ -137,7 +137,8 @@ export default function Counter({
     paddingLeft: horizontalPadding,
     paddingRight: horizontalPadding,
     color: textColor,
-    fontWeight
+    fontWeight,
+    direction: "ltr"
   };
 
   const defaultTopGradientStyle: React.CSSProperties = {

--- a/src/ts-tailwind/Components/Counter/Counter.tsx
+++ b/src/ts-tailwind/Components/Counter/Counter.tsx
@@ -160,7 +160,8 @@ export default function Counter({
     paddingRight: horizontalPadding,
     lineHeight: 1,
     color: textColor,
-    fontWeight
+    fontWeight,
+    direction: "ltr"
   };
 
   const gradientContainerStyle: React.CSSProperties = {


### PR DESCRIPTION
… direction

my html is rtl when trying this component i noticed that the numbers were counting up from the 10s and not 1s to display 21, idk how to explain it here but it was counting up from left to the right, i spent some time trying to figure it out and see what was causing the problem, until i realized that the actual number was 12 and not 21, then i knew the problem was with the doc direction and not the component, as soon as i styled the wrapper with direction: ltr; it worked just fine.

adding a default ltr style will help others.