### PR TITLE
fix(TabsLayout): resolve button overlap on mobile viewports.

### DIFF
--- a/src/components/common/TabsLayout.jsx
+++ b/src/components/common/TabsLayout.jsx
@@ -65,6 +65,7 @@ const TabsLayout = ({ children, className }) => {
     if (saved) toast.success?.(<>Added {nameEl} to favorites</>) ?? toast(<>Added {nameEl} to favorites</>);
     else toast.error?.(<>Removed {nameEl} from favorites</>) ?? toast(<>Removed {nameEl} from favorites</>);
   };
+
   const contentMap = {
     PreviewTab: null,
     CodeTab: null
@@ -79,8 +80,14 @@ const TabsLayout = ({ children, className }) => {
   return (
     <Tabs.Root w="100%" variant="plain" lazyMount defaultValue="preview" className={className}>
       <Tabs.List w="100%">
-        <Flex gap={2} justifyContent="space-between" alignItems="flex-start" w="100%" wrap="wrap">
-          <Flex gap={2} wrap="wrap" minW="0" flex="1">
+        <Flex
+          gap={2}
+          justifyContent={{ base: 'flex-start', md: 'space-between' }}
+          alignItems="center"
+          w="100%"
+          wrap="wrap"
+        >
+          <Flex gap={2} wrap="wrap" flex={{ base: 'none', md: '1' }}>
             <Tabs.Trigger value="preview" {...TAB_STYLE_PROPS}>
               <Icon as={FiEye} /> Preview
             </Tabs.Trigger>
@@ -90,7 +97,7 @@ const TabsLayout = ({ children, className }) => {
             </Tabs.Trigger>
           </Flex>
 
-          <Flex alignItems="center" gap={2} flexShrink={0}>
+          <Flex alignItems="center" gap={2} wrap="wrap">
             {hasChanges && (
               <Box
                 as="button"


### PR DESCRIPTION
## Summary

Fixes a layout bug in `TabsLayout` where the Reset button overlapped the Preview button on mobile viewports narrower than ~460px. 
At 390px (a common real-device width) the Reset button rendered directly behind the Preview button, making them inaccessible.

## Root Cause

The outer `Flex` container used `justifyContent="space-between"` with the right 
group set to `flexShrink={0}`. On narrow viewports where the two groups could 
not fit side by side, the right group refused to shrink and overlapped the left 
group instead of wrapping below it.

## Changes
*One file only*

**`src/components/common/TabsLayout.jsx`**

- Outer `Flex`: changed `alignItems` from `flex-start` to `center`, and made 
  `justifyContent` responsive — `space-between` on `md` and above (preserving 
  the original desktop layout), `flex-start` on smaller screens.
- Left `Flex` (Preview + Code): made `flex` responsive — `1` on `md` and above 
  to push the right group to the far end, `none` on mobile so it only occupies 
  what it needs and allows the right group to wrap cleanly below.
- Right `Flex` (Reset + Favorite + Contribute): removed `flexShrink={0}`, added 
  `wrap="wrap"` so buttons wrap internally on narrow screens instead of 
  overflowing or overlapping.
  
 ## Behavior

| Viewport | Before | After |
|---|---|---|
| Desktop (`md`+) | Left/right split with space between | Unchanged |
| ~460px and below | Reset overlaps Preview | All buttons wrap cleanly |
| 390px (common device) | Reset hidden behind Preview | Full row wraps, all accessible |

## Screenshots / Video

- **Before:**

<img width="460" height="771" alt="Screenshot 2026-03-25 at 2 22 46 PM" src="https://github.com/user-attachments/assets/af0781b9-bbd1-4dc3-93b6-f9eeaa210a6d" />

https://github.com/user-attachments/assets/696052e7-8cee-4a96-b3a8-746867883f96

---
- **After:**

<img width="528" height="1008" alt="Screenshot 2026-03-25 at 3 25 32 PM" src="https://github.com/user-attachments/assets/eb84521c-41ab-4293-a62a-ce905465ddcf" />

https://github.com/user-attachments/assets/2304d1a5-e63a-4553-9112-f2d539f05dc8

## Affected Files

- `src/components/common/TabsLayout.jsx`

## Testing

Tested locally across the following viewports using Chrome DevTools:
- 1280px — desktop layout unchanged
- 768px — desktop layout unchanged  
- 460px — buttons wrap cleanly, no overlap
- 430px — buttons wrap cleanly, no overlap
- 390px — buttons wrap cleanly, no overlap
- 360px — buttons wrap cleanly, no overlap

All tab interactions (Preview, Code, Contribute, Reset, Favorite) function correctly across all viewports.

Closes #925 