### PR TITLE
fix(Grainient): render initial frame in setSize to prevent flicker

### DIFF
--- a/src/content/Backgrounds/Grainient/Grainient.jsx
+++ b/src/content/Backgrounds/Grainient/Grainient.jsx
@@ -186,6 +186,7 @@ const Grainient = ({
       const res = program.uniforms.iResolution.value;
       res[0] = gl.drawingBufferWidth;
       res[1] = gl.drawingBufferHeight;
+      renderer.render({ scene: mesh });
     };
 
     const ro = new ResizeObserver(setSize);

--- a/src/tailwind/Backgrounds/Grainient/Grainient.jsx
+++ b/src/tailwind/Backgrounds/Grainient/Grainient.jsx
@@ -185,6 +185,7 @@ const Grainient = ({
       const res = program.uniforms.iResolution.value;
       res[0] = gl.drawingBufferWidth;
       res[1] = gl.drawingBufferHeight;
+      renderer.render({ scene: mesh });
     };
 
     const ro = new ResizeObserver(setSize);

--- a/src/ts-default/Backgrounds/Grainient/Grainient.tsx
+++ b/src/ts-default/Backgrounds/Grainient/Grainient.tsx
@@ -212,6 +212,7 @@ const Grainient: React.FC<GrainientProps> = ({
       const res = (program.uniforms.iResolution as { value: Float32Array }).value;
       res[0] = gl.drawingBufferWidth;
       res[1] = gl.drawingBufferHeight;
+      renderer.render({ scene: mesh });
     };
 
     const ro = new ResizeObserver(setSize);

--- a/src/ts-tailwind/Backgrounds/Grainient/Grainient.tsx
+++ b/src/ts-tailwind/Backgrounds/Grainient/Grainient.tsx
@@ -211,6 +211,7 @@ const Grainient: React.FC<GrainientProps> = ({
       const res = (program.uniforms.iResolution as { value: Float32Array }).value;
       res[0] = gl.drawingBufferWidth;
       res[1] = gl.drawingBufferHeight;
+      renderer.render({ scene: mesh });
     };
 
     const ro = new ResizeObserver(setSize);


### PR DESCRIPTION
## Problem                                                 
The `Grainient` component flickers on mount. When the component mounts, `setSize()` is called to configure the canvas dimensions — but `renderer.render()` only runs inside the `requestAnimationFrame` loop. This means the canvas stays blank for ~1 frame between mount and the first rAF tick, causing a visible flash against the page background.   
                                                                                                                                         
## Root Cause                                                          
`renderer.render()` was only called inside the animation loop, so the canvas stays blank until the next rAF tick fires.                
   
```js                                                                                                                                  
  const setSize = () => {                                                
    renderer.setSize(width, height);                                                                                                     
    res[0] = gl.drawingBufferWidth;            
    res[1] = gl.drawingBufferHeight;                                                                                                     
    // ❌ No render here — canvas is blank until next rAF                
};           
```                                                                                                                          
                                               
## Fix                                                                                                                                    
Added renderer.render({ scene: mesh }) inside setSize() so the canvas draws immediately whenever the size is set.                      
```js                              
  const setSize = () => {                                                                                                                
    renderer.setSize(width, height);                                     
    res[0] = gl.drawingBufferWidth;                          
    res[1] = gl.drawingBufferHeight;           
    renderer.render({ scene: mesh }); // ✅ Render immediately
  };        
```                                                                                                                             
   
This fix is applied to all 4 variants of the Grainient component (JS/TS × CSS/Tailwind).                                               
                                                                         
▎ Note: The same issue exists in Plasma and other OGL-based components — a follow-up PR will address those.                            
                                                                         
## Preview                                                                                                                                
### AS-IS                                                      
![react-bits-as-is](https://github.com/user-attachments/assets/c3460f6b-8aa6-4247-bfb1-e8fe31111725)
                                                   
### TO-BE                                                                                                                                  
![화면 기록 2026-03-30 17 28 32](https://github.com/user-attachments/assets/0a8c1e8b-4f1c-47fc-8561-81c5091ec632)
