### PR TITLE
fix(code-example): handle quote variants and dedupe injected props

### DIFF
--- a/src/components/code/CodeExample.jsx
+++ b/src/components/code/CodeExample.jsx
@@ -36,13 +36,23 @@ function injectPropsIntoCode(usageCode, props, defaultProps, componentName, demo
     const newPropLine =
       typeof propValue === 'boolean' && propValue === true ? propName : `${propName}=${formattedValue}`;
 
-    const simplePropRegex = new RegExp(`(^[ \\t]*)(${propName})(?:=(?:"[^"]*"|\\{[^{}\\n]*\\}))?[ \\t]*$`, 'gm');
+    const simplePropRegex = new RegExp(
+      `(^[ \\t]*)(${propName})(?:=(?:"[^"\\n]*"|'[^'\\n]*'|\\{[^{}\\n]*\\}|[^\\s/>]+))?[ \\t]*$`,
+      'gm'
+    );
 
     const hasSimpleMatch = simplePropRegex.test(result);
     simplePropRegex.lastIndex = 0;
 
     if (hasSimpleMatch) {
-      result = result.replace(simplePropRegex, `$1${newPropLine}`);
+      let seen = false;
+      result = result
+        .replace(simplePropRegex, (_, indent) => {
+          if (seen) return '';
+          seen = true;
+          return `${indent}${newPropLine}`;
+        })
+        .replace(/\n{3,}/g, '\n\n');
       continue;
     }
 

--- a/src/components/code/CodeExample.jsx
+++ b/src/components/code/CodeExample.jsx
@@ -37,7 +37,7 @@ function injectPropsIntoCode(usageCode, props, defaultProps, componentName, demo
       typeof propValue === 'boolean' && propValue === true ? propName : `${propName}=${formattedValue}`;
 
     const simplePropRegex = new RegExp(
-      `(^[ \\t]*)(${propName})(?:=(?:"[^"\\n]*"|'[^'\\n]*'|\\{[^{}\\n]*\\}|[^\\s/>]+))?[ \\t]*$`,
+      `(^[ \\t]*)(${propName})(?:=(?:"[^"\\n]*"|'[^'\\n]*'|\\{[^{}\\n]*\\}|[^\\s/>]+))?[ \\t]*(\\r?\\n|$)`,
       'gm'
     );
 
@@ -46,13 +46,11 @@ function injectPropsIntoCode(usageCode, props, defaultProps, componentName, demo
 
     if (hasSimpleMatch) {
       let seen = false;
-      result = result
-        .replace(simplePropRegex, (_, indent) => {
-          if (seen) return '';
-          seen = true;
-          return `${indent}${newPropLine}`;
-        })
-        .replace(/\n{3,}/g, '\n\n');
+      result = result.replace(simplePropRegex, (_, indent, __, lineEnding) => {
+        if (seen) return '';
+        seen = true;
+        return `${indent}${newPropLine}${lineEnding}`;
+      });
       continue;
     }
 


### PR DESCRIPTION
## Summary
This PR fixes a code-example rendering issue (#937) where the same prop could appear twice in the Usage snippet when quote styles differed.

## Problem
Some usage snippets had an existing prop written with single quotes, while dynamic prop updates are generated with double quotes.  
Because the matcher did not fully account for both styles, it could fail to detect the existing prop and append a new one, causing duplicates.

## Root Cause
The simple prop matcher handled only a subset of value formats and could miss valid single-quoted prop lines.  
When matching failed, fallback logic appended a new prop instead of replacing the existing one.

## Fix
- Expanded prop-line matching to support:
  - Single-quoted strings
  - Double-quoted strings
  - Braced values
  - Bare values
- Added deduplication so if multiple lines for the same prop exist, only one normalized line is kept.

## Why This Works
The injector now recognizes equivalent prop lines regardless of quote style and replaces them in place.  
If duplicates already exist, deduplication removes extras, preventing repeated props in generated Usage output.

## Scope
This change only affects code-example generation.  
There is no runtime behavior change to component logic.

## Validation
- Verified no new errors in the modified file.
- Confirmed duplicate-prop scenarios caused by quote-style mismatch are prevented.