### PR TITLE
[FIX]: Staggered Menu flicker on first dom render / page refresh

### DIFF
--- a/src/content/Components/StaggeredMenu/StaggeredMenu.css
+++ b/src/content/Components/StaggeredMenu/StaggeredMenu.css
@@ -141,6 +141,7 @@
   overflow-y: auto;
   z-index: 10;
   pointer-events: auto;
+  opacity: 0;
 }
 
 [data-position='left'] .staggered-menu-panel {
@@ -156,6 +157,7 @@
   width: clamp(260px, 38vw, 420px);
   pointer-events: none;
   z-index: 5;
+  opacity: 0;
 }
 
 [data-position='left'] .sm-prelayers {
@@ -170,6 +172,7 @@
   height: 100%;
   width: 100%;
   transform: translateX(0);
+  opacity: 0;
 }
 
 .sm-panel-inner {

--- a/src/content/Components/StaggeredMenu/StaggeredMenu.jsx
+++ b/src/content/Components/StaggeredMenu/StaggeredMenu.jsx
@@ -58,7 +58,10 @@ export const StaggeredMenu = ({
       preLayerElsRef.current = preLayers;
 
       const offscreen = position === 'left' ? -100 : 100;
-      gsap.set([panel, ...preLayers], { xPercent: offscreen });
+      gsap.set([panel, ...preLayers], { xPercent: offscreen, opacity: 1 });
+      if (preContainer) {
+        gsap.set(preContainer, { xPercent: 0, opacity: 1 });
+      }
       gsap.set(plusH, { transformOrigin: '50% 50%', rotate: 0 });
       gsap.set(plusV, { transformOrigin: '50% 50%', rotate: 90 });
       gsap.set(icon, { rotate: 0, transformOrigin: '50% 50%' });
@@ -85,8 +88,9 @@ export const StaggeredMenu = ({
     const socialTitle = panel.querySelector('.sm-socials-title');
     const socialLinks = Array.from(panel.querySelectorAll('.sm-socials-link'));
 
-    const layerStates = layers.map(el => ({ el, start: Number(gsap.getProperty(el, 'xPercent')) }));
-    const panelStart = Number(gsap.getProperty(panel, 'xPercent'));
+    const offscreen = position === 'left' ? -100 : 100;
+    const layerStates = layers.map(el => ({ el, start: offscreen }));
+    const panelStart = offscreen;
 
     if (itemEls.length) {
       gsap.set(itemEls, { yPercent: 140, rotate: 10 });

--- a/src/tailwind/Components/StaggeredMenu/StaggeredMenu.jsx
+++ b/src/tailwind/Components/StaggeredMenu/StaggeredMenu.jsx
@@ -64,7 +64,10 @@ export const StaggeredMenu = ({
       preLayerElsRef.current = preLayers;
 
       const offscreen = position === 'left' ? -100 : 100;
-      gsap.set([panel, ...preLayers], { xPercent: offscreen });
+      gsap.set([panel, ...preLayers], { xPercent: offscreen, opacity: 1 });
+      if (preContainer) {
+        gsap.set(preContainer, { xPercent: 0, opacity: 1 });
+      }
 
       gsap.set(plusH, { transformOrigin: '50% 50%', rotate: 0 });
       gsap.set(plusV, { transformOrigin: '50% 50%', rotate: 90 });
@@ -94,8 +97,9 @@ export const StaggeredMenu = ({
     const socialTitle = panel.querySelector('.sm-socials-title');
     const socialLinks = Array.from(panel.querySelectorAll('.sm-socials-link'));
 
-    const layerStates = layers.map(el => ({ el, start: Number(gsap.getProperty(el, 'xPercent')) }));
-    const panelStart = Number(gsap.getProperty(panel, 'xPercent'));
+    const offscreen = position === 'left' ? -100 : 100;
+    const layerStates = layers.map(el => ({ el, start: offscreen }));
+    const panelStart = offscreen;
 
     if (itemEls.length) gsap.set(itemEls, { yPercent: 140, rotate: 10 });
     if (numberEls.length) gsap.set(numberEls, { ['--sm-num-opacity']: 0 });

--- a/src/ts-default/Components/StaggeredMenu/StaggeredMenu.css
+++ b/src/ts-default/Components/StaggeredMenu/StaggeredMenu.css
@@ -141,6 +141,7 @@
   overflow-y: auto;
   z-index: 10;
   pointer-events: auto;
+  opacity: 0;
 }
 
 [data-position='left'] .staggered-menu-panel {
@@ -156,6 +157,7 @@
   width: clamp(260px, 38vw, 420px);
   pointer-events: none;
   z-index: 5;
+  opacity: 0;
 }
 
 [data-position='left'] .sm-prelayers {
@@ -170,6 +172,7 @@
   height: 100%;
   width: 100%;
   transform: translateX(0);
+  opacity: 0;
 }
 
 .sm-panel-inner {

--- a/src/ts-default/Components/StaggeredMenu/StaggeredMenu.tsx
+++ b/src/ts-default/Components/StaggeredMenu/StaggeredMenu.tsx
@@ -88,7 +88,10 @@ export const StaggeredMenu: React.FC<StaggeredMenuProps> = ({
       preLayerElsRef.current = preLayers;
 
       const offscreen = position === 'left' ? -100 : 100;
-      gsap.set([panel, ...preLayers], { xPercent: offscreen });
+      gsap.set([panel, ...preLayers], { xPercent: offscreen, opacity: 1 });
+      if (preContainer) {
+        gsap.set(preContainer, { xPercent: 0, opacity: 1 });
+      }
       gsap.set(plusH, { transformOrigin: '50% 50%', rotate: 0 });
       gsap.set(plusV, { transformOrigin: '50% 50%', rotate: 90 });
       gsap.set(icon, { rotate: 0, transformOrigin: '50% 50%' });
@@ -117,8 +120,9 @@ export const StaggeredMenu: React.FC<StaggeredMenuProps> = ({
     const socialTitle = panel.querySelector('.sm-socials-title') as HTMLElement | null;
     const socialLinks = Array.from(panel.querySelectorAll('.sm-socials-link')) as HTMLElement[];
 
-    const layerStates = layers.map(el => ({ el, start: Number(gsap.getProperty(el, 'xPercent')) }));
-    const panelStart = Number(gsap.getProperty(panel, 'xPercent'));
+    const offscreen = position === 'left' ? -100 : 100;
+    const layerStates = layers.map(el => ({ el, start: offscreen }));
+    const panelStart = offscreen;
 
     if (itemEls.length) {
       gsap.set(itemEls, { yPercent: 140, rotate: 10 });

--- a/src/ts-tailwind/Components/StaggeredMenu/StaggeredMenu.tsx
+++ b/src/ts-tailwind/Components/StaggeredMenu/StaggeredMenu.tsx
@@ -92,7 +92,10 @@ export const StaggeredMenu: React.FC<StaggeredMenuProps> = ({
       preLayerElsRef.current = preLayers;
 
       const offscreen = position === 'left' ? -100 : 100;
-      gsap.set([panel, ...preLayers], { xPercent: offscreen });
+      gsap.set([panel, ...preLayers], { xPercent: offscreen, opacity: 1 });
+      if (preContainer) {
+        gsap.set(preContainer, { xPercent: 0, opacity: 1 });
+      }
 
       gsap.set(plusH, { transformOrigin: '50% 50%', rotate: 0 });
       gsap.set(plusV, { transformOrigin: '50% 50%', rotate: 90 });
@@ -124,8 +127,9 @@ export const StaggeredMenu: React.FC<StaggeredMenuProps> = ({
     const socialTitle = panel.querySelector('.sm-socials-title') as HTMLElement | null;
     const socialLinks = Array.from(panel.querySelectorAll('.sm-socials-link')) as HTMLElement[];
 
-    const layerStates = layers.map(el => ({ el, start: Number(gsap.getProperty(el, 'xPercent')) }));
-    const panelStart = Number(gsap.getProperty(panel, 'xPercent'));
+    const offscreen = position === 'left' ? -100 : 100;
+    const layerStates = layers.map(el => ({ el, start: offscreen }));
+    const panelStart = offscreen;
 
     if (itemEls.length) gsap.set(itemEls, { yPercent: 140, rotate: 10 });
     if (numberEls.length) gsap.set(numberEls, { ['--sm-num-opacity' as any]: 0 });


### PR DESCRIPTION
Closes #942

https://github.com/user-attachments/assets/37834756-a1fd-4cd8-8634-c60afc572d95

The fixes identified:

Opacity initialization (line 96): Added [opacity: 1](vscode-file://vscode-app/c:/Users/aighita/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to the initial [gsap.set](vscode-file://vscode-app/c:/Users/aighita/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) call for panel and pre-layers, plus explicit setup of the preContainer with proper opacity.

Consistent positioning (lines 125-126): Instead of dynamically querying [gsap.getProperty()](vscode-file://vscode-app/c:/Users/aighita/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) for xPercent values, the fixed version uses the [offscreen](vscode-file://vscode-app/c:/Users/aighita/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) constant directly. This ensures consistent values throughout the animation lifecycle and prevents timing-related flickering.

The CSS needs to hide the panel and prelayers initially with [opacity: 0](vscode-file://vscode-app/c:/Users/aighita/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html).