### PR TITLE
fix(GradualBlur): reduce the bundle size from 60.55kB gzip to 8.14kB gzip

### DIFF
--- a/public/r/registry.json
+++ b/public/r/registry.json
@@ -528,9 +528,7 @@
 			"title": "GradualBlur",
 			"description": "Progressively un-blurs content based on scroll or trigger creating a cinematic reveal.",
 			"type": "registry:component",
-			"dependencies": [
-				"mathjs@^14.6.0"
-			],
+			"dependencies": [],
 			"registryDependencies": [],
 			"files": [
 				{
@@ -548,9 +546,7 @@
 			"title": "GradualBlur",
 			"description": "Progressively un-blurs content based on scroll or trigger creating a cinematic reveal.",
 			"type": "registry:component",
-			"dependencies": [
-				"mathjs@^14.6.0"
-			],
+			"dependencies": [],
 			"registryDependencies": [],
 			"files": [
 				{
@@ -564,9 +560,7 @@
 			"title": "GradualBlur",
 			"description": "Progressively un-blurs content based on scroll or trigger creating a cinematic reveal.",
 			"type": "registry:component",
-			"dependencies": [
-				"mathjs@^14.6.0"
-			],
+			"dependencies": [],
 			"registryDependencies": [],
 			"files": [
 				{
@@ -584,9 +578,7 @@
 			"title": "GradualBlur",
 			"description": "Progressively un-blurs content based on scroll or trigger creating a cinematic reveal.",
 			"type": "registry:component",
-			"dependencies": [
-				"mathjs@^14.6.0"
-			],
+			"dependencies": [],
 			"registryDependencies": [],
 			"files": [
 				{
@@ -7262,15 +7254,15 @@
 			"files": [
 				{
 					"type": "registry:component",
-					"path": "Hyperspeed/HyperSpeedPresets.js"
-				},
-				{
-					"type": "registry:component",
 					"path": "Hyperspeed/Hyperspeed.css"
 				},
 				{
 					"type": "registry:component",
 					"path": "Hyperspeed/Hyperspeed.jsx"
+				},
+				{
+					"type": "registry:component",
+					"path": "Hyperspeed/HyperSpeedPresets.js"
 				}
 			]
 		},
@@ -7287,11 +7279,11 @@
 			"files": [
 				{
 					"type": "registry:component",
-					"path": "Hyperspeed/HyperSpeedPresets.js"
+					"path": "Hyperspeed/Hyperspeed.jsx"
 				},
 				{
 					"type": "registry:component",
-					"path": "Hyperspeed/Hyperspeed.jsx"
+					"path": "Hyperspeed/HyperSpeedPresets.js"
 				}
 			]
 		},
@@ -7308,15 +7300,15 @@
 			"files": [
 				{
 					"type": "registry:component",
-					"path": "Hyperspeed/HyperSpeedPresets.ts"
-				},
-				{
-					"type": "registry:component",
 					"path": "Hyperspeed/Hyperspeed.css"
 				},
 				{
 					"type": "registry:component",
 					"path": "Hyperspeed/Hyperspeed.tsx"
+				},
+				{
+					"type": "registry:component",
+					"path": "Hyperspeed/HyperSpeedPresets.ts"
 				}
 			]
 		},
@@ -7333,11 +7325,11 @@
 			"files": [
 				{
 					"type": "registry:component",
-					"path": "Hyperspeed/HyperSpeedPresets.ts"
+					"path": "Hyperspeed/Hyperspeed.tsx"
 				},
 				{
 					"type": "registry:component",
-					"path": "Hyperspeed/Hyperspeed.tsx"
+					"path": "Hyperspeed/HyperSpeedPresets.ts"
 				}
 			]
 		},

--- a/src/content/Animations/GradualBlur/GradualBlur.jsx
+++ b/src/content/Animations/GradualBlur/GradualBlur.jsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useRef, useState, useMemo } from 'react';
-import * as math from 'mathjs';
 
 import './GradualBlur.css';
 
@@ -128,15 +127,15 @@ function GradualBlur(props) {
 
       let blurValue;
       if (config.exponential) {
-        blurValue = math.pow(2, progress * 4) * 0.0625 * currentStrength;
+        blurValue = Math.pow(2, progress * 4) * 0.0625 * currentStrength;
       } else {
         blurValue = 0.0625 * (progress * config.divCount + 1) * currentStrength;
       }
 
-      const p1 = math.round((increment * i - increment) * 10) / 10;
-      const p2 = math.round(increment * i * 10) / 10;
-      const p3 = math.round((increment * i + increment) * 10) / 10;
-      const p4 = math.round((increment * i + increment * 2) * 10) / 10;
+      const p1 = Math.round((increment * i - increment) * 10) / 10;
+      const p2 = Math.round(increment * i * 10) / 10;
+      const p3 = Math.round((increment * i + increment) * 10) / 10;
+      const p4 = Math.round((increment * i + increment * 2) * 10) / 10;
 
       let gradient = `transparent ${p1}%, black ${p2}%`;
       if (p3 <= 100) gradient += `, black ${p3}%`;

--- a/src/tailwind/Animations/GradualBlur/GradualBlur.jsx
+++ b/src/tailwind/Animations/GradualBlur/GradualBlur.jsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useRef, useState, useMemo } from 'react';
-import * as math from 'mathjs';
 
 const DEFAULT_CONFIG = {
   position: 'bottom',
@@ -128,14 +127,14 @@ const GradualBlur = props => {
 
       let blurValue;
       if (config.exponential) {
-        blurValue = math.pow(2, progress * 4) * 0.0625 * currentStrength;
+        blurValue = Math.pow(2, progress * 4) * 0.0625 * currentStrength;
       } else {
         blurValue = 0.0625 * (progress * config.divCount + 1) * currentStrength;
       }
-      const p1 = math.round((increment * i - increment) * 10) / 10;
-      const p2 = math.round(increment * i * 10) / 10;
-      const p3 = math.round((increment * i + increment) * 10) / 10;
-      const p4 = math.round((increment * i + increment * 2) * 10) / 10;
+      const p1 = Math.round((increment * i - increment) * 10) / 10;
+      const p2 = Math.round(increment * i * 10) / 10;
+      const p3 = Math.round((increment * i + increment) * 10) / 10;
+      const p4 = Math.round((increment * i + increment * 2) * 10) / 10;
       let gradient = `transparent ${p1}%, black ${p2}%`;
       if (p3 <= 100) gradient += `, black ${p3}%`;
       if (p4 <= 100) gradient += `, transparent ${p4}%`;

--- a/src/ts-default/Animations/GradualBlur/GradualBlur.tsx
+++ b/src/ts-default/Animations/GradualBlur/GradualBlur.tsx
@@ -1,5 +1,4 @@
 import React, { CSSProperties, useEffect, useRef, useState, useMemo, PropsWithChildren } from 'react';
-import * as math from 'mathjs';
 
 import './GradualBlur.css';
 
@@ -188,15 +187,15 @@ const GradualBlur: React.FC<PropsWithChildren<GradualBlurProps>> = props => {
 
       let blurValue: number;
       if (config.exponential) {
-        blurValue = Number(math.pow(2, progress * 4)) * 0.0625 * currentStrength;
+        blurValue = Number(Math.pow(2, progress * 4)) * 0.0625 * currentStrength;
       } else {
         blurValue = 0.0625 * (progress * config.divCount + 1) * currentStrength;
       }
 
-      const p1 = math.round((increment * i - increment) * 10) / 10;
-      const p2 = math.round(increment * i * 10) / 10;
-      const p3 = math.round((increment * i + increment) * 10) / 10;
-      const p4 = math.round((increment * i + increment * 2) * 10) / 10;
+      const p1 = Math.round((increment * i - increment) * 10) / 10;
+      const p2 = Math.round(increment * i * 10) / 10;
+      const p3 = Math.round((increment * i + increment) * 10) / 10;
+      const p4 = Math.round((increment * i + increment * 2) * 10) / 10;
 
       let gradient = `transparent ${p1}%, black ${p2}%`;
       if (p3 <= 100) gradient += `, black ${p3}%`;

--- a/src/ts-tailwind/Animations/GradualBlur/GradualBlur.tsx
+++ b/src/ts-tailwind/Animations/GradualBlur/GradualBlur.tsx
@@ -1,5 +1,4 @@
 import React, { CSSProperties, useEffect, useRef, useState, useMemo, PropsWithChildren } from 'react';
-import * as math from 'mathjs';
 
 type GradualBlurProps = PropsWithChildren<{
   position?: 'top' | 'bottom' | 'left' | 'right';
@@ -191,15 +190,15 @@ const GradualBlur: React.FC<GradualBlurProps> = props => {
 
       let blurValue: number;
       if (config.exponential) {
-        blurValue = Number(math.pow(2, progress * 4)) * 0.0625 * currentStrength;
+        blurValue = Number(Math.pow(2, progress * 4)) * 0.0625 * currentStrength;
       } else {
         blurValue = 0.0625 * (progress * config.divCount + 1) * currentStrength;
       }
 
-      const p1 = math.round((increment * i - increment) * 10) / 10;
-      const p2 = math.round(increment * i * 10) / 10;
-      const p3 = math.round((increment * i + increment) * 10) / 10;
-      const p4 = math.round((increment * i + increment * 2) * 10) / 10;
+      const p1 = Math.round((increment * i - increment) * 10) / 10;
+      const p2 = Math.round(increment * i * 10) / 10;
+      const p3 = Math.round((increment * i + increment) * 10) / 10;
+      const p4 = Math.round((increment * i + increment * 2) * 10) / 10;
 
       let gradient = `transparent ${p1}%, black ${p2}%`;
       if (p3 <= 100) gradient += `, black ${p3}%`;


### PR DESCRIPTION
Removed the `mathjs` import which was not needed and was just bloating the bundle. It was used just for the `round` and `pow` function which are provided by `Math`. It does not change the behavior of the component and optimizes the bundle a lot. 

Before:
<img width="1512" height="128" alt="Screenshot 2026-04-16 224541" src="https://github.com/user-attachments/assets/67570159-ef93-41d4-91de-6008e994bc18" />

After:
<img width="1522" height="129" alt="Screenshot 2026-04-16 224449" src="https://github.com/user-attachments/assets/6e544d6c-7d8e-40e6-87cd-0ab3051fdba2" />
