### PR TITLE
Change transform-origin to center for scroll cards

### DIFF
--- a/src/content/Components/ScrollStack/ScrollStack.css
+++ b/src/content/Components/ScrollStack/ScrollStack.css
@@ -22,7 +22,8 @@
 }
 
 .scroll-stack-card {
-  transform-origin: top center;
+ transform-origin: center center;
+  transition: transform 0.3s ease, opacity 0.3s ease;
   will-change: transform, filter;
   backface-visibility: hidden;
   transform-style: preserve-3d;


### PR DESCRIPTION
Fix the component jitter issue when using ScrollStack with useWindowScroll=true.