### PR TITLE
fix(Navbar): render docs mobile menu via portal to escape backdrop-filter

### DIFF
--- a/src/components/landingnew/Navbar/Navbar.jsx
+++ b/src/components/landingnew/Navbar/Navbar.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import { createPortal } from 'react-dom';
 import { Link, useLocation } from 'react-router-dom';
 import { Logo } from '../../common/SVGComponents';
 import { useStars } from '../../../hooks/useStars';
@@ -215,57 +216,56 @@ const Navbar = ({ showDocs }) => {
           </button>
         </div>
 
-        {menuOpen && (
+        {menuOpen && !showDocs && (
+          <div className="ln-navbar-mobile-menu">
+            {NAV_LINKS.map(({ label, to }) => (
+              <Link key={to} className="ln-navbar-mobile-link" to={to} onClick={() => setMenuOpen(false)}>
+                {label}
+              </Link>
+            ))}
+            <span className="ln-navbar-mobile-link">
+              Community <span className="ln-navbar-soon">Soon</span>
+            </span>
+          </div>
+        )}
+
+        {menuOpen && showDocs && createPortal(
           <>
-            {showDocs && <div className="ln-navbar-mobile-backdrop" onClick={() => setMenuOpen(false)} />}
-            <div className={`ln-navbar-mobile-menu${showDocs ? ' ln-navbar-mobile-menu-docs' : ''}`}>
-              {showDocs ? (
-                <>
-                  <div className="ln-navbar-mobile-scroll">
-                    {CATEGORIES.map((cat, i) => {
-                      const slug = str => str.replace(/\s+/g, '-').toLowerCase();
-                      return (
-                        <div className="ln-navbar-mobile-section" key={cat.name}>
-                          <span className="ln-navbar-mobile-label">{cat.name}</span>
-                          {cat.subcategories.map(sub => (
-                            <Link
-                              key={sub}
-                              className="ln-navbar-mobile-link"
-                              to={`/${slug(cat.name)}/${slug(sub)}`}
-                              onClick={() => setMenuOpen(false)}
-                            >
-                              {sub}
+            <div className="ln-navbar-mobile-backdrop" onClick={() => setMenuOpen(false)} />
+            <div className="ln-navbar-mobile-menu ln-navbar-mobile-menu-docs">
+              <div className="ln-navbar-mobile-scroll">
+                {CATEGORIES.map((cat, i) => {
+                  const slug = str => str.replace(/\s+/g, '-').toLowerCase();
+                  return (
+                    <div className="ln-navbar-mobile-section" key={cat.name}>
+                      <span className="ln-navbar-mobile-label">{cat.name}</span>
+                      {cat.subcategories.map(sub => (
+                        <Link
+                          key={sub}
+                          className="ln-navbar-mobile-link"
+                          to={`/${slug(cat.name)}/${slug(sub)}`}
+                          onClick={() => setMenuOpen(false)}
+                        >
+                          {sub}
+                        </Link>
+                      ))}
+                      {i === 0 && (
+                        <>
+                          <span className="ln-navbar-mobile-label" style={{ marginTop: 12 }}>Tools</span>
+                          {TOOLS.map(tool => (
+                            <Link key={tool.id} className="ln-navbar-mobile-link" to={tool.path} onClick={() => setMenuOpen(false)}>
+                              {tool.label}
                             </Link>
                           ))}
-                          {i === 0 && (
-                            <>
-                              <span className="ln-navbar-mobile-label" style={{ marginTop: 12 }}>Tools</span>
-                              {TOOLS.map(tool => (
-                                <Link key={tool.id} className="ln-navbar-mobile-link" to={tool.path} onClick={() => setMenuOpen(false)}>
-                                  {tool.label}
-                                </Link>
-                              ))}
-                            </>
-                          )}
-                        </div>
-                      );
-                    })}
-                  </div>
-                </>
-              ) : (
-                <>
-                  {NAV_LINKS.map(({ label, to }) => (
-                    <Link key={to} className="ln-navbar-mobile-link" to={to} onClick={() => setMenuOpen(false)}>
-                      {label}
-                    </Link>
-                  ))}
-                  <span className="ln-navbar-mobile-link">
-                    Community <span className="ln-navbar-soon">Soon</span>
-                  </span>
-                </>
-              )}
+                        </>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
             </div>
-          </>
+          </>,
+          document.body
         )}
       </div>
     </header>


### PR DESCRIPTION
## Summary

- Fixes mobile navigation menu on docs pages not appearing when the page is scrolled down
- The menu toggle, scroll lock, and close behavior all worked correctly, only the panel itself was invisible
- Root cause: CSS `backdrop-filter` on the scrolled navbar creates a containing block that traps `position: fixed` children

---

## Root Cause

When the user scrolls past ~50px, the `.ln-navbar-scrolled` class applies:

```css
backdrop-filter: blur(24px);
```

to `.ln-navbar-inner`.

Per the CSS spec, any element with `backdrop-filter` acts as a containing block for `position: fixed` descendants. This caused the docs mobile menu (which uses `position: fixed` to cover the full viewport) to be positioned and clipped inside the 60px navbar element, making it completely invisible to the user.

This only affected the **docs variant** of the menu (`showDocs` prop) because it's the one using `position: fixed`. The landing page mobile menu uses `position: absolute` and was unaffected.

---

## Fix

Render the docs mobile menu (and its backdrop overlay) via `ReactDOM.createPortal` directly into `document.body`. This moves the nodes outside the `backdrop-filter` ancestor in the real DOM, while keeping them fully inside the React component tree.

This means:

- React event bubbling still works normally (e.g. `onClick` to close the menu)
- `z-index` stacking is now relative to `body`, which is more reliable
- Scroll lock, backdrop click-to-close, and all category links behave identically
- The non-docs (landing page) mobile menu is untouched, it stays inline since it doesn't need `position: fixed`

---

## Why this approach

| Option | Verdict |
|------|--------|
| `createPortal` to `document.body` | Minimal, targeted, no visual changes |
| Remove `backdrop-filter` from scrolled navbar | Breaks the frosted glass scroll effect |
| Apply blur via `::before` pseudo-element | Complex and fragile cross-browser |
| Lift menu state and render outside `<Navbar>` | Requires broader refactor |

---

## Test Plan

- [x] Open a docs page (e.g. `/get-started/introduction`) on a mobile viewport (≤ 768px)
- [x] Scroll down until the navbar blur effect appears
- [x] Tap the hamburger icon, menu should open and cover the full screen
- [x] Tap a category link, should navigate and close the menu
- [x] Tap the ✕ icon, should close the menu and restore scroll
- [x] Repeat at the top of the page (not scrolled), should still work as before
- [x] Verify landing page mobile menu (non-docs) is unaffected

---

*Real mobile device (safari browser) showing the fix:*

https://github.com/user-attachments/assets/d00593af-5371-4785-9489-e9e9a9ca248b

---

*browser DevTools (chrome) showing the fix:*

https://github.com/user-attachments/assets/5df491d7-4a67-41aa-92e3-b060f497f45c

---

Any feedback, adjustments, or improvements to this fix are very welcome. happy to update the PR based on your review.

Closese #948 