### PR TITLE
fix: correct ComponentPropsProvider usage in 8 background demos

### DIFF
--- a/src/demo/Backgrounds/GradientBlindsDemo.jsx
+++ b/src/demo/Backgrounds/GradientBlindsDemo.jsx
@@ -154,7 +154,7 @@ const GradientBlindsDemo = () => {
   );
 
   return (
-    <ComponentPropsProvider hasChanges={hasChanges} resetProps={resetProps}>
+    <ComponentPropsProvider props={props} defaultProps={DEFAULT_PROPS} hasChanges={hasChanges} resetProps={resetProps}>
       <TabsLayout>
         <PreviewTab>
           <Box position="relative" className="demo-container" h={500} p={0} overflow="hidden">

--- a/src/demo/Backgrounds/GridDistortionDemo.jsx
+++ b/src/demo/Backgrounds/GridDistortionDemo.jsx
@@ -73,7 +73,7 @@ const GridDistortionDemo = () => {
   );
 
   return (
-    <ComponentPropsProvider resetProps={resetProps} hasChanges={hasChanges}>
+    <ComponentPropsProvider props={props} defaultProps={DEFAULT_PROPS} resetProps={resetProps} hasChanges={hasChanges}>
       <TabsLayout>
         <PreviewTab>
           <Box position="relative" className="demo-container" h={500} p={0} overflow="hidden" ref={containerRef}>

--- a/src/demo/Backgrounds/GridScanDemo.jsx
+++ b/src/demo/Backgrounds/GridScanDemo.jsx
@@ -10,7 +10,6 @@ import PreviewSlider from '../../components/common/Preview/PreviewSlider';
 import PreviewSwitch from '@/components/common/Preview/PreviewSwitch';
 import PreviewColorPickerCustom from '../../components/common/Preview/PreviewColorPickerCustom';
 
-import useForceRerender from '../../hooks/useForceRerender';
 import useComponentProps from '../../hooks/useComponentProps';
 import { ComponentPropsProvider } from '../../components/context/ComponentPropsContext';
 
@@ -50,8 +49,6 @@ const GridScanDemo = () => {
     enableWebcam,
     showPreview
   } = props;
-
-  const [key, forceRerender] = useForceRerender();
 
   const propData = useMemo(
     () => [
@@ -103,12 +100,11 @@ const GridScanDemo = () => {
   );
 
   return (
-    <ComponentPropsProvider resetProps={resetProps} hasChanges={hasChanges} forceRerender={forceRerender}>
+    <ComponentPropsProvider props={props} defaultProps={DEFAULT_PROPS} resetProps={resetProps} hasChanges={hasChanges}>
       <TabsLayout>
         <PreviewTab>
           <Box position="relative" className="demo-container" h={500} p={0} overflow="hidden">
             <GridScan
-              key={key}
               lineThickness={lineThickness}
               gridScale={gridScale}
               lineJitter={lineJitter}

--- a/src/demo/Backgrounds/LetterGlitchDemo.jsx
+++ b/src/demo/Backgrounds/LetterGlitchDemo.jsx
@@ -75,7 +75,7 @@ const LetterGlitchDemo = () => {
   );
 
   return (
-    <ComponentPropsProvider resetProps={resetProps} hasChanges={hasChanges}>
+    <ComponentPropsProvider props={props} defaultProps={DEFAULT_PROPS} resetProps={resetProps} hasChanges={hasChanges}>
       <TabsLayout>
         <PreviewTab>
           <Box position="relative" className="demo-container" h={500} overflow="hidden" p={0}>

--- a/src/demo/Backgrounds/LiquidChromeDemo.jsx
+++ b/src/demo/Backgrounds/LiquidChromeDemo.jsx
@@ -82,7 +82,7 @@ const LiquidChromeDemo = () => {
   );
 
   return (
-    <ComponentPropsProvider resetProps={resetProps} hasChanges={hasChanges}>
+    <ComponentPropsProvider props={props} defaultProps={DEFAULT_PROPS} resetProps={resetProps} hasChanges={hasChanges}>
       <TabsLayout>
         <PreviewTab>
           <Box position="relative" className="demo-container" h={500} p={0} overflow="hidden">

--- a/src/demo/Backgrounds/PlasmaDemo.jsx
+++ b/src/demo/Backgrounds/PlasmaDemo.jsx
@@ -13,7 +13,6 @@ import PreviewSelect from '../../components/common/Preview/PreviewSelect';
 import PreviewColorPickerCustom from '../../components/common/Preview/PreviewColorPickerCustom';
 import OpenInStudioButton from '../../components/common/Preview/OpenInStudioButton';
 
-import useForceRerender from '../../hooks/useForceRerender';
 import useComponentProps from '../../hooks/useComponentProps';
 import { ComponentPropsProvider } from '../../components/context/ComponentPropsContext';
 
@@ -33,8 +32,6 @@ const DEFAULT_PROPS = {
 const PlasmaDemo = () => {
   const { props, updateProp, resetProps, hasChanges } = useComponentProps(DEFAULT_PROPS);
   const { color, speed, direction, scale, opacity, mouseInteractive } = props;
-  const [key, forceRerender] = useForceRerender();
-
   const propData = useMemo(
     () => [
       {
@@ -78,12 +75,11 @@ const PlasmaDemo = () => {
   );
 
   return (
-    <ComponentPropsProvider resetProps={resetProps} hasChanges={hasChanges} forceRerender={forceRerender}>
+    <ComponentPropsProvider props={props} defaultProps={DEFAULT_PROPS} resetProps={resetProps} hasChanges={hasChanges}>
       <TabsLayout>
         <PreviewTab>
           <Box position="relative" className="demo-container" h={500} p={0} overflow="hidden">
             <Plasma
-              key={key}
               color={color}
               speed={speed}
               direction={direction}

--- a/src/demo/Backgrounds/RippleGridDemo.jsx
+++ b/src/demo/Backgrounds/RippleGridDemo.jsx
@@ -2,7 +2,6 @@ import { useMemo } from 'react';
 import { CodeTab, PreviewTab, TabsLayout } from '../../components/common/TabsLayout';
 import { Box, Flex } from '@chakra-ui/react';
 
-import useForceRerender from '../../hooks/useForceRerender';
 import useComponentProps from '../../hooks/useComponentProps';
 import { ComponentPropsProvider } from '../../components/context/ComponentPropsContext';
 
@@ -51,8 +50,6 @@ const RippleGridDemo = () => {
     mouseInteraction,
     mouseInteractionRadius
   } = props;
-
-  const [key, forceRerender] = useForceRerender();
 
   const propData = useMemo(
     () => [
@@ -133,12 +130,11 @@ const RippleGridDemo = () => {
   );
 
   return (
-    <ComponentPropsProvider value={{ props, updateProp, resetProps, hasChanges, forceRerender, DEFAULT_PROPS }}>
+    <ComponentPropsProvider props={props} defaultProps={DEFAULT_PROPS} resetProps={resetProps} hasChanges={hasChanges}>
       <TabsLayout>
         <PreviewTab>
           <Box position="relative" className="demo-container" h={500} overflow="hidden">
             <RippleGrid
-              key={key}
               enableRainbow={enableRainbow}
               gridColor={gridColor}
               rippleIntensity={rippleIntensity}

--- a/src/demo/Backgrounds/SilkDemo.jsx
+++ b/src/demo/Backgrounds/SilkDemo.jsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { CodeTab, PreviewTab, TabsLayout } from '../../components/common/TabsLayout';
 import { Box, Flex } from '@chakra-ui/react';
 
@@ -31,6 +31,11 @@ const SilkDemo = () => {
   const { speed, scale, color, noiseIntensity, rotation } = props;
 
   const [key, forceRerender] = useForceRerender();
+
+  const handleReset = useCallback(() => {
+    resetProps();
+    forceRerender();
+  }, [resetProps, forceRerender]);
 
   const propData = useMemo(
     () => [
@@ -69,7 +74,7 @@ const SilkDemo = () => {
   );
 
   return (
-    <ComponentPropsProvider reset={resetProps} hasChanges={hasChanges}>
+    <ComponentPropsProvider props={props} defaultProps={DEFAULT_PROPS} resetProps={handleReset} hasChanges={hasChanges}>
       <TabsLayout>
         <PreviewTab>
           <Box position="relative" className="demo-container" h={500} overflow="hidden" p={0}>


### PR DESCRIPTION
# fix: correct ComponentPropsProvider usage in 8 background demos

## Problem

Several background demo components had incorrect or incomplete `ComponentPropsProvider` usage, causing two distinct bugs:

### Bug 1: Reset button visible but non-functional
`ComponentPropsProvider` accepts a `resetProps` prop that wires the reset button in `TabsLayout`. Some demos either passed it under the wrong name (`reset=` instead of `resetProps=`) or used a completely wrong interface (`value={{ ... }}`), causing the context to fall back to its default no-op `resetProps: () => {}`. The reset button would appear (because `hasChanges` was passed correctly) but clicking it did nothing and URL state was never cleared.

### Bug 2: "Copy Prompt" ignores user customizations
`ComponentPropsProvider` also accepts `props` and `defaultProps` which are consumed by `TabsLayout`'s "Copy Prompt" feature to inject the user's current customized values into the usage code snippet. Without these, the copied AI prompt always contained the static default usage example, silently ignoring any prop changes the user had made.

### Bug 3: Dead code (`useForceRerender` unused)
Three demos declared `useForceRerender` and passed `forceRerender` either to the provider (which doesn't accept it) or nowhere at all. The `key={key}` was applied to the component but since `forceRerender` was never called, the key never changed, making both the hook and the key entirely dead code.

---

## How to Reproduce

### Example 1: Reset button appears but does nothing

**URL:** https://www.reactbits.dev/backgrounds/silk

1. Open the Silk background demo
2. Adjust any slider or color (e.g. change Speed or Color)
3. The **Reset** button appears in the top-right toolbar
4. Click **Reset**
5. **Expected:** props reset to defaults, URL params cleared, component remounts
6. **Actual:** nothing happens, button click is silently ignored, customized values persist

**Root cause:** `ComponentPropsProvider` was receiving `reset={resetProps}` (wrong prop name) instead of `resetProps={resetProps}`, so the context fell back to its default no-op function.

### Example 2: Reset button not shown at all

**URL:** https://www.reactbits.dev/backgrounds/ripple-grid

1. Open the Ripple Grid background demo
2. Adjust any slider or color
3. **Expected:** Reset button appears in the toolbar
4. **Actual:** Reset button never appears

**Root cause:** `ComponentPropsProvider` was receiving a `value={{ ... }}` object (wrong interface entirely), so `hasChanges` and `resetProps` were both `undefined` in the context, the button never rendered and had no handler.

---

## Changes

### `SilkDemo.jsx`
- **Fixed** `reset={resetProps}` → `resetProps={handleReset}` (wrong prop name)
- **Added** missing `props={props}` and `defaultProps={DEFAULT_PROPS}`
- **Added** `handleReset` combining `resetProps()` + `forceRerender()` so the component remounts on reset (required because Silk uses `key={key}` to remount its WebGL context on every prop change)
- **Added** `useCallback` import

### `RippleGridDemo.jsx`
- **Fixed** completely wrong `value={{ props, updateProp, resetProps, hasChanges, forceRerender, DEFAULT_PROPS }}` interface — replaced with correct individual props
- **Removed** dead `useForceRerender` import, hook call, and `key={key}` on the component (none of the `onChange` handlers called `forceRerender`, so key never changed)

### `GridScanDemo.jsx`
- **Added** missing `props={props}` and `defaultProps={DEFAULT_PROPS}`
- **Removed** `forceRerender={forceRerender}` from provider (unrecognized prop, silently ignored)
- **Removed** dead `useForceRerender` import, hook call, and `key={key}` on the component

### `PlasmaDemo.jsx`
- **Added** missing `props={props}` and `defaultProps={DEFAULT_PROPS}`
- **Removed** `forceRerender={forceRerender}` from provider (unrecognized prop, silently ignored)
- **Removed** dead `useForceRerender` import, hook call, and `key={key}` on the component

### `GradientBlindsDemo.jsx`
- **Added** missing `props={props}` and `defaultProps={DEFAULT_PROPS}`

### `LetterGlitchDemo.jsx`
- **Added** missing `props={props}` and `defaultProps={DEFAULT_PROPS}`

### `LiquidChromeDemo.jsx`
- **Added** missing `props={props}` and `defaultProps={DEFAULT_PROPS}`

### `GridDistortionDemo.jsx`
- **Added** missing `props={props}` and `defaultProps={DEFAULT_PROPS}`

---

## Root Cause

All affected demos were missing one or more required props on `ComponentPropsProvider`. The correct interface is:

```jsx
<ComponentPropsProvider
  props={props}
  defaultProps={DEFAULT_PROPS}
  resetProps={resetProps}
  hasChanges={hasChanges}
>
```

`SilkDemo` additionally needed `resetProps` to call `forceRerender()` because the Silk component relies on `key` remounting to apply changes to its WebGL context, matching the pattern already used in `SplashCursorDemo`.

---

## Checklist

- [x] Reset button works and clears URL state on all 8 demos
- [x] "Copy Prompt" reflects user's customized prop values on all 8 demos
- [x] No dead imports or unused variables
- [x] No unrecognized props passed to `ComponentPropsProvider`
- [x] All changes follow existing codebase patterns
- [x] No new abstractions or refactors introduced, minimal targeted fixes only