### PR TITLE
Fix Chrome black screen issue on Browse Components navigation

### DIFF
--- a/src/css/transitions.css
+++ b/src/css/transitions.css
@@ -23,8 +23,17 @@
   pointer-events: none;
 }
 
+.category-page {
+  will-change: opacity;
+  transform: translateZ(0);
+  -webkit-transform: translateZ(0);
+  backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
+}
+
 .category-page.loading {
   pointer-events: none;
+  opacity: 1;
 }
 
 .skeleton-loader {


### PR DESCRIPTION

##  Problem
When clicking the "Browse Components" button on the landing page in Chrome browser, a blank black screen appears instead of loading the components page. However, this works fine in Firefox, Safari, and Edge browsers.

##  Root Cause Analysis
The issue was caused by a **CSS rendering bug in Chrome** affecting the `.category-page` element during page transitions. When the page-transition-fade effect was applied, the element's opacity wasn't being properly handled by Chrome's rendering engine, causing the content to become invisible.

The transition CSS was missing:
- GPU acceleration hints
- Proper stacking context
- Render optimization properties

## Solution
Updated `src/css/transitions.css` to add CSS properties that enable GPU acceleration and proper rendering in Chrome:

```css
.category-page {
  will-change: opacity;              /* Tells browser to optimize for opacity changes */
  transform: translateZ(0);          /* Creates new stacking context & enables GPU acceleration */
  -webkit-transform: translateZ(0);  /* Safari/Chrome support */
  backface-visibility: hidden;       /* Prevents flickering and rendering artifacts */
  -webkit-backface-visibility: hidden;
}

.category-page.loading {
  opacity: 1;  /* Ensures content remains visible during loading state */
}