### PR TITLE
Feat/lanyard front back images

### DIFF
--- a/src/constants/code/Components/lanyardCode.js
+++ b/src/constants/code/Components/lanyardCode.js
@@ -12,6 +12,7 @@ export const lanyard = {
 
 // Pass custom images for the card's front/back faces and/or the lanyard band.
 // frontImage and backImage render independently; imageFit keeps aspect ratio.
+// lanyardWidth widens the band so a custom band image has more room.
 <Lanyard
   position={[0, 0, 20]}
   gravity={[0, -40, 0]}
@@ -19,6 +20,7 @@ export const lanyard = {
   backImage="/my-back.png"
   imageFit="cover"
   lanyardImage="/my-band.png"
+  lanyardWidth={1}
 />
 
 /* IMPORTANT INFO BELOW

--- a/src/constants/code/Components/lanyardCode.js
+++ b/src/constants/code/Components/lanyardCode.js
@@ -10,6 +10,17 @@ export const lanyard = {
 
 <Lanyard position={[0, 0, 20]} gravity={[0, -40, 0]} />
 
+// Pass custom images for the card's front/back faces and/or the lanyard band.
+// frontImage and backImage render independently; imageFit keeps aspect ratio.
+<Lanyard
+  position={[0, 0, 20]}
+  gravity={[0, -40, 0]}
+  frontImage="/my-front.png"
+  backImage="/my-back.png"
+  imageFit="cover"
+  lanyardImage="/my-band.png"
+/>
+
 /* IMPORTANT INFO BELOW
 
 1. You MUST have the card.glb and lanyard.png files in your project and import them
@@ -17,6 +28,7 @@ export const lanyard = {
 
 2. You can edit your card.glb file in this online .glb editor and change the texture:
 - https://modelviewer.dev/editor/
+- alternatively, pass the "frontImage" / "backImage" props to swap the card's faces at runtime
 
 4. The png file is the texture for the lanyard's band and can be edited in any image editor
 

--- a/src/content/Components/Lanyard/Lanyard.jsx
+++ b/src/content/Components/Lanyard/Lanyard.jsx
@@ -35,7 +35,8 @@ export default function Lanyard({
   frontImage = null,
   backImage = null,
   imageFit = 'cover',
-  lanyardImage = null
+  lanyardImage = null,
+  lanyardWidth = 1
 }) {
   const [isMobile, setIsMobile] = useState(() => typeof window !== 'undefined' && window.innerWidth < 768);
 
@@ -61,6 +62,7 @@ export default function Lanyard({
             backImage={backImage}
             imageFit={imageFit}
             lanyardImage={lanyardImage}
+            lanyardWidth={lanyardWidth}
           />
         </Physics>
         <Environment blur={0.75}>
@@ -104,7 +106,8 @@ function Band({
   frontImage = null,
   backImage = null,
   imageFit = 'cover',
-  lanyardImage = null
+  lanyardImage = null,
+  lanyardWidth = 1
 }) {
   const band = useRef(),
     fixed = useRef(),
@@ -273,7 +276,7 @@ function Band({
           useMap
           map={texture}
           repeat={[-4, 1]}
-          lineWidth={1}
+          lineWidth={lanyardWidth}
         />
       </mesh>
     </>

--- a/src/content/Components/Lanyard/Lanyard.jsx
+++ b/src/content/Components/Lanyard/Lanyard.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-unknown-property */
 'use client';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Canvas, extend, useFrame } from '@react-three/fiber';
 import { useGLTF, useTexture, Environment, Lightformer } from '@react-three/drei';
 import { BallCollider, CuboidCollider, Physics, RigidBody, useRopeJoint, useSphericalJoint } from '@react-three/rapier';
@@ -15,7 +15,28 @@ import './Lanyard.css';
 
 extend({ MeshLineGeometry, MeshLineMaterial });
 
-export default function Lanyard({ position = [0, 0, 30], gravity = [0, -40, 0], fov = 20, transparent = true }) {
+// 1x1 transparent pixel — lets useTexture be called unconditionally when a
+// front/back image isn't supplied.
+const BLANK_PIXEL =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+// The card model's front face is UV-mapped to the LEFT half of the texture
+// atlas and the back face to the RIGHT half (measured from card.glb). Each
+// custom image is composited into its own half so the two faces render
+// independently, aspect-preserving (no stretching).
+const FRONT_UV_RECT = { x: 0, y: 0, w: 0.5, h: 0.755 };
+const BACK_UV_RECT = { x: 0.5, y: 0, w: 0.5, h: 0.757 };
+
+export default function Lanyard({
+  position = [0, 0, 30],
+  gravity = [0, -40, 0],
+  fov = 20,
+  transparent = true,
+  frontImage = null,
+  backImage = null,
+  imageFit = 'cover',
+  lanyardImage = null
+}) {
   const [isMobile, setIsMobile] = useState(() => typeof window !== 'undefined' && window.innerWidth < 768);
 
   useEffect(() => {
@@ -34,7 +55,13 @@ export default function Lanyard({ position = [0, 0, 30], gravity = [0, -40, 0], 
       >
         <ambientLight intensity={Math.PI} />
         <Physics gravity={gravity} timeStep={isMobile ? 1 / 30 : 1 / 60}>
-          <Band isMobile={isMobile} />
+          <Band
+            isMobile={isMobile}
+            frontImage={frontImage}
+            backImage={backImage}
+            imageFit={imageFit}
+            lanyardImage={lanyardImage}
+          />
         </Physics>
         <Environment blur={0.75}>
           <Lightformer
@@ -70,7 +97,15 @@ export default function Lanyard({ position = [0, 0, 30], gravity = [0, -40, 0], 
     </div>
   );
 }
-function Band({ maxSpeed = 50, minSpeed = 0, isMobile = false }) {
+function Band({
+  maxSpeed = 50,
+  minSpeed = 0,
+  isMobile = false,
+  frontImage = null,
+  backImage = null,
+  imageFit = 'cover',
+  lanyardImage = null
+}) {
   const band = useRef(),
     fixed = useRef(),
     j1 = useRef(),
@@ -83,7 +118,58 @@ function Band({ maxSpeed = 50, minSpeed = 0, isMobile = false }) {
     dir = new THREE.Vector3();
   const segmentProps = { type: 'dynamic', canSleep: true, colliders: false, angularDamping: 4, linearDamping: 4 };
   const { nodes, materials } = useGLTF(cardGLB);
-  const texture = useTexture(lanyard);
+  const texture = useTexture(lanyardImage || lanyard);
+  // useTexture must be called unconditionally; use a blank pixel when an image
+  // isn't supplied for a given face, then skip compositing it below.
+  const frontTex = useTexture(frontImage || BLANK_PIXEL);
+  const backTex = useTexture(backImage || BLANK_PIXEL);
+
+  // Composite the front/back images into the card's texture atlas (front = left
+  // half, back = right half). Each image is drawn aspect-preserving (no stretch).
+  const cardMap = useMemo(() => {
+    const baseMap = materials.base.map;
+    if (!frontImage && !backImage) return baseMap;
+
+    const baseImg = baseMap.image;
+    const W = baseImg.width;
+    const H = baseImg.height;
+    const canvas = document.createElement('canvas');
+    canvas.width = W;
+    canvas.height = H;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return baseMap;
+    // Keep the original baked atlas for the card edges and any untouched face.
+    ctx.drawImage(baseImg, 0, 0, W, H);
+
+    const drawFitted = (img, rect) => {
+      const rx = rect.x * W;
+      const ry = rect.y * H;
+      const rw = rect.w * W;
+      const rh = rect.h * H;
+      const pick = imageFit === 'contain' ? Math.min : Math.max;
+      const scale = pick(rw / img.width, rh / img.height);
+      const dw = img.width * scale;
+      const dh = img.height * scale;
+      const dx = rx + (rw - dw) / 2;
+      const dy = ry + (rh - dh) / 2;
+      ctx.save();
+      ctx.beginPath();
+      ctx.rect(rx, ry, rw, rh);
+      ctx.clip();
+      ctx.drawImage(img, dx, dy, dw, dh);
+      ctx.restore();
+    };
+
+    if (frontImage && frontTex.image) drawFitted(frontTex.image, FRONT_UV_RECT);
+    if (backImage && backTex.image) drawFitted(backTex.image, BACK_UV_RECT);
+
+    const composite = new THREE.CanvasTexture(canvas);
+    composite.colorSpace = THREE.SRGBColorSpace;
+    composite.flipY = baseMap.flipY;
+    composite.anisotropy = 16;
+    composite.needsUpdate = true;
+    return composite;
+  }, [frontImage, backImage, imageFit, frontTex, backTex, materials.base.map]);
   const [curve] = useState(
     () =>
       new THREE.CatmullRomCurve3([new THREE.Vector3(), new THREE.Vector3(), new THREE.Vector3(), new THREE.Vector3()])
@@ -165,7 +251,7 @@ function Band({ maxSpeed = 50, minSpeed = 0, isMobile = false }) {
           >
             <mesh geometry={nodes.card.geometry}>
               <meshPhysicalMaterial
-                map={materials.base.map}
+                map={cardMap}
                 map-anisotropy={16}
                 clearcoat={isMobile ? 0 : 1}
                 clearcoatRoughness={0.15}

--- a/src/demo/Components/LanyardDemo.jsx
+++ b/src/demo/Components/LanyardDemo.jsx
@@ -77,6 +77,12 @@ const LanyardDemo = () => {
         type: 'string',
         default: 'null',
         description: "Custom image URL for the lanyard band's repeating texture. Falls back to the default band texture when not set."
+      },
+      {
+        name: 'lanyardWidth',
+        type: 'number',
+        default: '1',
+        description: 'Width of the lanyard band (meshline lineWidth). Increase it to give a custom band image more room and reduce stretching.'
       }
     ],
     []

--- a/src/demo/Components/LanyardDemo.jsx
+++ b/src/demo/Components/LanyardDemo.jsx
@@ -53,6 +53,30 @@ const LanyardDemo = () => {
         type: 'boolean',
         default: 'true',
         description: 'Enables a transparent background for the canvas.'
+      },
+      {
+        name: 'frontImage',
+        type: 'string',
+        default: 'null',
+        description: "Custom image URL for the card's front face. Falls back to the model's built-in texture when not set."
+      },
+      {
+        name: 'backImage',
+        type: 'string',
+        default: 'null',
+        description: "Custom image URL for the card's back face, rendered independently from the front."
+      },
+      {
+        name: 'imageFit',
+        type: '"cover" | "contain"',
+        default: '"cover"',
+        description: "How a custom front/back image fits its face. Both preserve aspect ratio; 'cover' fills and crops, 'contain' letterboxes."
+      },
+      {
+        name: 'lanyardImage',
+        type: 'string',
+        default: 'null',
+        description: "Custom image URL for the lanyard band's repeating texture. Falls back to the default band texture when not set."
       }
     ],
     []

--- a/src/tailwind/Components/Lanyard/Lanyard.jsx
+++ b/src/tailwind/Components/Lanyard/Lanyard.jsx
@@ -34,7 +34,8 @@ export default function Lanyard({
   frontImage = null,
   backImage = null,
   imageFit = 'cover',
-  lanyardImage = null
+  lanyardImage = null,
+  lanyardWidth = 1
 }) {
   const [isMobile, setIsMobile] = useState(() => typeof window !== 'undefined' && window.innerWidth < 768);
 
@@ -60,6 +61,7 @@ export default function Lanyard({
             backImage={backImage}
             imageFit={imageFit}
             lanyardImage={lanyardImage}
+            lanyardWidth={lanyardWidth}
           />
         </Physics>
         <Environment blur={0.75}>
@@ -103,7 +105,8 @@ function Band({
   frontImage = null,
   backImage = null,
   imageFit = 'cover',
-  lanyardImage = null
+  lanyardImage = null,
+  lanyardWidth = 1
 }) {
   const band = useRef(),
     fixed = useRef(),
@@ -272,7 +275,7 @@ function Band({
           useMap
           map={texture}
           repeat={[-4, 1]}
-          lineWidth={1}
+          lineWidth={lanyardWidth}
         />
       </mesh>
     </>

--- a/src/tailwind/Components/Lanyard/Lanyard.jsx
+++ b/src/tailwind/Components/Lanyard/Lanyard.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-unknown-property */
 'use client';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Canvas, extend, useFrame } from '@react-three/fiber';
 import { useGLTF, useTexture, Environment, Lightformer } from '@react-three/drei';
 import { BallCollider, CuboidCollider, Physics, RigidBody, useRopeJoint, useSphericalJoint } from '@react-three/rapier';
@@ -14,7 +14,28 @@ import * as THREE from 'three';
 
 extend({ MeshLineGeometry, MeshLineMaterial });
 
-export default function Lanyard({ position = [0, 0, 30], gravity = [0, -40, 0], fov = 20, transparent = true }) {
+// 1x1 transparent pixel — lets useTexture be called unconditionally when a
+// front/back image isn't supplied.
+const BLANK_PIXEL =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+// The card model's front face is UV-mapped to the LEFT half of the texture
+// atlas and the back face to the RIGHT half (measured from card.glb). Each
+// custom image is composited into its own half so the two faces render
+// independently, aspect-preserving (no stretching).
+const FRONT_UV_RECT = { x: 0, y: 0, w: 0.5, h: 0.755 };
+const BACK_UV_RECT = { x: 0.5, y: 0, w: 0.5, h: 0.757 };
+
+export default function Lanyard({
+  position = [0, 0, 30],
+  gravity = [0, -40, 0],
+  fov = 20,
+  transparent = true,
+  frontImage = null,
+  backImage = null,
+  imageFit = 'cover',
+  lanyardImage = null
+}) {
   const [isMobile, setIsMobile] = useState(() => typeof window !== 'undefined' && window.innerWidth < 768);
 
   useEffect(() => {
@@ -33,7 +54,13 @@ export default function Lanyard({ position = [0, 0, 30], gravity = [0, -40, 0], 
       >
         <ambientLight intensity={Math.PI} />
         <Physics gravity={gravity} timeStep={isMobile ? 1 / 30 : 1 / 60}>
-          <Band isMobile={isMobile} />
+          <Band
+            isMobile={isMobile}
+            frontImage={frontImage}
+            backImage={backImage}
+            imageFit={imageFit}
+            lanyardImage={lanyardImage}
+          />
         </Physics>
         <Environment blur={0.75}>
           <Lightformer
@@ -69,7 +96,15 @@ export default function Lanyard({ position = [0, 0, 30], gravity = [0, -40, 0], 
     </div>
   );
 }
-function Band({ maxSpeed = 50, minSpeed = 0, isMobile = false }) {
+function Band({
+  maxSpeed = 50,
+  minSpeed = 0,
+  isMobile = false,
+  frontImage = null,
+  backImage = null,
+  imageFit = 'cover',
+  lanyardImage = null
+}) {
   const band = useRef(),
     fixed = useRef(),
     j1 = useRef(),
@@ -82,7 +117,58 @@ function Band({ maxSpeed = 50, minSpeed = 0, isMobile = false }) {
     dir = new THREE.Vector3();
   const segmentProps = { type: 'dynamic', canSleep: true, colliders: false, angularDamping: 4, linearDamping: 4 };
   const { nodes, materials } = useGLTF(cardGLB);
-  const texture = useTexture(lanyard);
+  const texture = useTexture(lanyardImage || lanyard);
+  // useTexture must be called unconditionally; use a blank pixel when an image
+  // isn't supplied for a given face, then skip compositing it below.
+  const frontTex = useTexture(frontImage || BLANK_PIXEL);
+  const backTex = useTexture(backImage || BLANK_PIXEL);
+
+  // Composite the front/back images into the card's texture atlas (front = left
+  // half, back = right half). Each image is drawn aspect-preserving (no stretch).
+  const cardMap = useMemo(() => {
+    const baseMap = materials.base.map;
+    if (!frontImage && !backImage) return baseMap;
+
+    const baseImg = baseMap.image;
+    const W = baseImg.width;
+    const H = baseImg.height;
+    const canvas = document.createElement('canvas');
+    canvas.width = W;
+    canvas.height = H;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return baseMap;
+    // Keep the original baked atlas for the card edges and any untouched face.
+    ctx.drawImage(baseImg, 0, 0, W, H);
+
+    const drawFitted = (img, rect) => {
+      const rx = rect.x * W;
+      const ry = rect.y * H;
+      const rw = rect.w * W;
+      const rh = rect.h * H;
+      const pick = imageFit === 'contain' ? Math.min : Math.max;
+      const scale = pick(rw / img.width, rh / img.height);
+      const dw = img.width * scale;
+      const dh = img.height * scale;
+      const dx = rx + (rw - dw) / 2;
+      const dy = ry + (rh - dh) / 2;
+      ctx.save();
+      ctx.beginPath();
+      ctx.rect(rx, ry, rw, rh);
+      ctx.clip();
+      ctx.drawImage(img, dx, dy, dw, dh);
+      ctx.restore();
+    };
+
+    if (frontImage && frontTex.image) drawFitted(frontTex.image, FRONT_UV_RECT);
+    if (backImage && backTex.image) drawFitted(backTex.image, BACK_UV_RECT);
+
+    const composite = new THREE.CanvasTexture(canvas);
+    composite.colorSpace = THREE.SRGBColorSpace;
+    composite.flipY = baseMap.flipY;
+    composite.anisotropy = 16;
+    composite.needsUpdate = true;
+    return composite;
+  }, [frontImage, backImage, imageFit, frontTex, backTex, materials.base.map]);
   const [curve] = useState(
     () =>
       new THREE.CatmullRomCurve3([new THREE.Vector3(), new THREE.Vector3(), new THREE.Vector3(), new THREE.Vector3()])
@@ -164,7 +250,7 @@ function Band({ maxSpeed = 50, minSpeed = 0, isMobile = false }) {
           >
             <mesh geometry={nodes.card.geometry}>
               <meshPhysicalMaterial
-                map={materials.base.map}
+                map={cardMap}
                 map-anisotropy={16}
                 clearcoat={isMobile ? 0 : 1}
                 clearcoatRoughness={0.15}

--- a/src/ts-default/Components/Lanyard/Lanyard.tsx
+++ b/src/ts-default/Components/Lanyard/Lanyard.tsx
@@ -44,6 +44,7 @@ interface LanyardProps {
   backImage?: string | null;
   imageFit?: 'cover' | 'contain';
   lanyardImage?: string | null;
+  lanyardWidth?: number;
 }
 
 export default function Lanyard({
@@ -54,7 +55,8 @@ export default function Lanyard({
   frontImage = null,
   backImage = null,
   imageFit = 'cover',
-  lanyardImage = null
+  lanyardImage = null,
+  lanyardWidth = 1
 }: LanyardProps) {
   const [isMobile, setIsMobile] = useState<boolean>(() => typeof window !== 'undefined' && window.innerWidth < 768);
 
@@ -80,6 +82,7 @@ export default function Lanyard({
             backImage={backImage}
             imageFit={imageFit}
             lanyardImage={lanyardImage}
+            lanyardWidth={lanyardWidth}
           />
         </Physics>
         <Environment blur={0.75}>
@@ -125,6 +128,7 @@ interface BandProps {
   backImage?: string | null;
   imageFit?: 'cover' | 'contain';
   lanyardImage?: string | null;
+  lanyardWidth?: number;
 }
 
 function Band({
@@ -134,7 +138,8 @@ function Band({
   frontImage = null,
   backImage = null,
   imageFit = 'cover',
-  lanyardImage = null
+  lanyardImage = null,
+  lanyardWidth = 1
 }: BandProps) {
   // Using "any" for refs since the exact types depend on Rapier's internals
   const band = useRef<any>(null);
@@ -327,7 +332,7 @@ function Band({
           useMap
           map={texture}
           repeat={[-4, 1]}
-          lineWidth={1}
+          lineWidth={lanyardWidth}
         />
       </mesh>
     </>

--- a/src/ts-default/Components/Lanyard/Lanyard.tsx
+++ b/src/ts-default/Components/Lanyard/Lanyard.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-unknown-property */
 'use client';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Canvas, extend, useFrame } from '@react-three/fiber';
 import { useGLTF, useTexture, Environment, Lightformer } from '@react-three/drei';
 import {
@@ -23,18 +23,38 @@ import './Lanyard.css';
 
 extend({ MeshLineGeometry, MeshLineMaterial });
 
+// 1x1 transparent pixel — lets useTexture be called unconditionally when a
+// front/back image isn't supplied.
+const BLANK_PIXEL =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+// The card model's front face is UV-mapped to the LEFT half of the texture
+// atlas and the back face to the RIGHT half (measured from card.glb). Each
+// custom image is composited into its own half so the two faces render
+// independently, aspect-preserving (no stretching).
+const FRONT_UV_RECT = { x: 0, y: 0, w: 0.5, h: 0.755 };
+const BACK_UV_RECT = { x: 0.5, y: 0, w: 0.5, h: 0.757 };
+
 interface LanyardProps {
   position?: [number, number, number];
   gravity?: [number, number, number];
   fov?: number;
   transparent?: boolean;
+  frontImage?: string | null;
+  backImage?: string | null;
+  imageFit?: 'cover' | 'contain';
+  lanyardImage?: string | null;
 }
 
 export default function Lanyard({
   position = [0, 0, 30],
   gravity = [0, -40, 0],
   fov = 20,
-  transparent = true
+  transparent = true,
+  frontImage = null,
+  backImage = null,
+  imageFit = 'cover',
+  lanyardImage = null
 }: LanyardProps) {
   const [isMobile, setIsMobile] = useState<boolean>(() => typeof window !== 'undefined' && window.innerWidth < 768);
 
@@ -54,7 +74,13 @@ export default function Lanyard({
       >
         <ambientLight intensity={Math.PI} />
         <Physics gravity={gravity} timeStep={isMobile ? 1 / 30 : 1 / 60}>
-          <Band isMobile={isMobile} />
+          <Band
+            isMobile={isMobile}
+            frontImage={frontImage}
+            backImage={backImage}
+            imageFit={imageFit}
+            lanyardImage={lanyardImage}
+          />
         </Physics>
         <Environment blur={0.75}>
           <Lightformer
@@ -95,9 +121,21 @@ interface BandProps {
   maxSpeed?: number;
   minSpeed?: number;
   isMobile?: boolean;
+  frontImage?: string | null;
+  backImage?: string | null;
+  imageFit?: 'cover' | 'contain';
+  lanyardImage?: string | null;
 }
 
-function Band({ maxSpeed = 50, minSpeed = 0, isMobile = false }: BandProps) {
+function Band({
+  maxSpeed = 50,
+  minSpeed = 0,
+  isMobile = false,
+  frontImage = null,
+  backImage = null,
+  imageFit = 'cover',
+  lanyardImage = null
+}: BandProps) {
   // Using "any" for refs since the exact types depend on Rapier's internals
   const band = useRef<any>(null);
   const fixed = useRef<any>(null);
@@ -120,7 +158,58 @@ function Band({ maxSpeed = 50, minSpeed = 0, isMobile = false }: BandProps) {
   };
 
   const { nodes, materials } = useGLTF(cardGLB) as any;
-  const texture = useTexture(lanyard);
+  const texture = useTexture(lanyardImage || lanyard);
+  // useTexture must be called unconditionally; use a blank pixel when an image
+  // isn't supplied for a given face, then skip compositing it below.
+  const frontTex = useTexture(frontImage || BLANK_PIXEL);
+  const backTex = useTexture(backImage || BLANK_PIXEL);
+
+  // Composite the front/back images into the card's texture atlas (front = left
+  // half, back = right half). Each image is drawn aspect-preserving (no stretch).
+  const cardMap = useMemo(() => {
+    const baseMap = materials.base.map as THREE.Texture;
+    if (!frontImage && !backImage) return baseMap;
+
+    const baseImg = baseMap.image as any;
+    const W = baseImg.width;
+    const H = baseImg.height;
+    const canvas = document.createElement('canvas');
+    canvas.width = W;
+    canvas.height = H;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return baseMap;
+    // Keep the original baked atlas for the card edges and any untouched face.
+    ctx.drawImage(baseImg, 0, 0, W, H);
+
+    const drawFitted = (img: any, rect: typeof FRONT_UV_RECT) => {
+      const rx = rect.x * W;
+      const ry = rect.y * H;
+      const rw = rect.w * W;
+      const rh = rect.h * H;
+      const pick = imageFit === 'contain' ? Math.min : Math.max;
+      const scale = pick(rw / img.width, rh / img.height);
+      const dw = img.width * scale;
+      const dh = img.height * scale;
+      const dx = rx + (rw - dw) / 2;
+      const dy = ry + (rh - dh) / 2;
+      ctx.save();
+      ctx.beginPath();
+      ctx.rect(rx, ry, rw, rh);
+      ctx.clip();
+      ctx.drawImage(img, dx, dy, dw, dh);
+      ctx.restore();
+    };
+
+    if (frontImage && frontTex.image) drawFitted(frontTex.image, FRONT_UV_RECT);
+    if (backImage && backTex.image) drawFitted(backTex.image, BACK_UV_RECT);
+
+    const composite = new THREE.CanvasTexture(canvas);
+    composite.colorSpace = THREE.SRGBColorSpace;
+    composite.flipY = baseMap.flipY;
+    composite.anisotropy = 16;
+    composite.needsUpdate = true;
+    return composite;
+  }, [frontImage, backImage, imageFit, frontTex, backTex, materials.base.map]);
   const [curve] = useState(
     () =>
       new THREE.CatmullRomCurve3([new THREE.Vector3(), new THREE.Vector3(), new THREE.Vector3(), new THREE.Vector3()])
@@ -216,7 +305,7 @@ function Band({ maxSpeed = 50, minSpeed = 0, isMobile = false }: BandProps) {
           >
             <mesh geometry={nodes.card.geometry}>
               <meshPhysicalMaterial
-                map={materials.base.map}
+                map={cardMap}
                 map-anisotropy={16}
                 clearcoat={isMobile ? 0 : 1}
                 clearcoatRoughness={0.15}

--- a/src/ts-tailwind/Components/Lanyard/Lanyard.tsx
+++ b/src/ts-tailwind/Components/Lanyard/Lanyard.tsx
@@ -42,6 +42,7 @@ interface LanyardProps {
   backImage?: string | null;
   imageFit?: 'cover' | 'contain';
   lanyardImage?: string | null;
+  lanyardWidth?: number;
 }
 
 export default function Lanyard({
@@ -52,7 +53,8 @@ export default function Lanyard({
   frontImage = null,
   backImage = null,
   imageFit = 'cover',
-  lanyardImage = null
+  lanyardImage = null,
+  lanyardWidth = 1
 }: LanyardProps) {
   const [isMobile, setIsMobile] = useState<boolean>(() => typeof window !== 'undefined' && window.innerWidth < 768);
 
@@ -78,6 +80,7 @@ export default function Lanyard({
             backImage={backImage}
             imageFit={imageFit}
             lanyardImage={lanyardImage}
+            lanyardWidth={lanyardWidth}
           />
         </Physics>
         <Environment blur={0.75}>
@@ -123,6 +126,7 @@ interface BandProps {
   backImage?: string | null;
   imageFit?: 'cover' | 'contain';
   lanyardImage?: string | null;
+  lanyardWidth?: number;
 }
 
 function Band({
@@ -132,7 +136,8 @@ function Band({
   frontImage = null,
   backImage = null,
   imageFit = 'cover',
-  lanyardImage = null
+  lanyardImage = null,
+  lanyardWidth = 1
 }: BandProps) {
   // Using "any" for refs since the exact types depend on Rapier's internals
   const band = useRef<any>(null);
@@ -325,7 +330,7 @@ function Band({
           useMap
           map={texture}
           repeat={[-4, 1]}
-          lineWidth={1}
+          lineWidth={lanyardWidth}
         />
       </mesh>
     </>

--- a/src/ts-tailwind/Components/Lanyard/Lanyard.tsx
+++ b/src/ts-tailwind/Components/Lanyard/Lanyard.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-unknown-property */
 'use client';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Canvas, extend, useFrame } from '@react-three/fiber';
 import { useGLTF, useTexture, Environment, Lightformer } from '@react-three/drei';
 import {
@@ -21,18 +21,38 @@ import lanyard from './lanyard.png';
 
 extend({ MeshLineGeometry, MeshLineMaterial });
 
+// 1x1 transparent pixel — lets useTexture be called unconditionally when a
+// front/back image isn't supplied.
+const BLANK_PIXEL =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+// The card model's front face is UV-mapped to the LEFT half of the texture
+// atlas and the back face to the RIGHT half (measured from card.glb). Each
+// custom image is composited into its own half so the two faces render
+// independently, aspect-preserving (no stretching).
+const FRONT_UV_RECT = { x: 0, y: 0, w: 0.5, h: 0.755 };
+const BACK_UV_RECT = { x: 0.5, y: 0, w: 0.5, h: 0.757 };
+
 interface LanyardProps {
   position?: [number, number, number];
   gravity?: [number, number, number];
   fov?: number;
   transparent?: boolean;
+  frontImage?: string | null;
+  backImage?: string | null;
+  imageFit?: 'cover' | 'contain';
+  lanyardImage?: string | null;
 }
 
 export default function Lanyard({
   position = [0, 0, 30],
   gravity = [0, -40, 0],
   fov = 20,
-  transparent = true
+  transparent = true,
+  frontImage = null,
+  backImage = null,
+  imageFit = 'cover',
+  lanyardImage = null
 }: LanyardProps) {
   const [isMobile, setIsMobile] = useState<boolean>(() => typeof window !== 'undefined' && window.innerWidth < 768);
 
@@ -52,7 +72,13 @@ export default function Lanyard({
       >
         <ambientLight intensity={Math.PI} />
         <Physics gravity={gravity} timeStep={isMobile ? 1 / 30 : 1 / 60}>
-          <Band isMobile={isMobile} />
+          <Band
+            isMobile={isMobile}
+            frontImage={frontImage}
+            backImage={backImage}
+            imageFit={imageFit}
+            lanyardImage={lanyardImage}
+          />
         </Physics>
         <Environment blur={0.75}>
           <Lightformer
@@ -93,9 +119,21 @@ interface BandProps {
   maxSpeed?: number;
   minSpeed?: number;
   isMobile?: boolean;
+  frontImage?: string | null;
+  backImage?: string | null;
+  imageFit?: 'cover' | 'contain';
+  lanyardImage?: string | null;
 }
 
-function Band({ maxSpeed = 50, minSpeed = 0, isMobile = false }: BandProps) {
+function Band({
+  maxSpeed = 50,
+  minSpeed = 0,
+  isMobile = false,
+  frontImage = null,
+  backImage = null,
+  imageFit = 'cover',
+  lanyardImage = null
+}: BandProps) {
   // Using "any" for refs since the exact types depend on Rapier's internals
   const band = useRef<any>(null);
   const fixed = useRef<any>(null);
@@ -118,7 +156,58 @@ function Band({ maxSpeed = 50, minSpeed = 0, isMobile = false }: BandProps) {
   };
 
   const { nodes, materials } = useGLTF(cardGLB) as any;
-  const texture = useTexture(lanyard);
+  const texture = useTexture(lanyardImage || lanyard);
+  // useTexture must be called unconditionally; use a blank pixel when an image
+  // isn't supplied for a given face, then skip compositing it below.
+  const frontTex = useTexture(frontImage || BLANK_PIXEL);
+  const backTex = useTexture(backImage || BLANK_PIXEL);
+
+  // Composite the front/back images into the card's texture atlas (front = left
+  // half, back = right half). Each image is drawn aspect-preserving (no stretch).
+  const cardMap = useMemo(() => {
+    const baseMap = materials.base.map as THREE.Texture;
+    if (!frontImage && !backImage) return baseMap;
+
+    const baseImg = baseMap.image as any;
+    const W = baseImg.width;
+    const H = baseImg.height;
+    const canvas = document.createElement('canvas');
+    canvas.width = W;
+    canvas.height = H;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return baseMap;
+    // Keep the original baked atlas for the card edges and any untouched face.
+    ctx.drawImage(baseImg, 0, 0, W, H);
+
+    const drawFitted = (img: any, rect: typeof FRONT_UV_RECT) => {
+      const rx = rect.x * W;
+      const ry = rect.y * H;
+      const rw = rect.w * W;
+      const rh = rect.h * H;
+      const pick = imageFit === 'contain' ? Math.min : Math.max;
+      const scale = pick(rw / img.width, rh / img.height);
+      const dw = img.width * scale;
+      const dh = img.height * scale;
+      const dx = rx + (rw - dw) / 2;
+      const dy = ry + (rh - dh) / 2;
+      ctx.save();
+      ctx.beginPath();
+      ctx.rect(rx, ry, rw, rh);
+      ctx.clip();
+      ctx.drawImage(img, dx, dy, dw, dh);
+      ctx.restore();
+    };
+
+    if (frontImage && frontTex.image) drawFitted(frontTex.image, FRONT_UV_RECT);
+    if (backImage && backTex.image) drawFitted(backTex.image, BACK_UV_RECT);
+
+    const composite = new THREE.CanvasTexture(canvas);
+    composite.colorSpace = THREE.SRGBColorSpace;
+    composite.flipY = baseMap.flipY;
+    composite.anisotropy = 16;
+    composite.needsUpdate = true;
+    return composite;
+  }, [frontImage, backImage, imageFit, frontTex, backTex, materials.base.map]);
   const [curve] = useState(
     () =>
       new THREE.CatmullRomCurve3([new THREE.Vector3(), new THREE.Vector3(), new THREE.Vector3(), new THREE.Vector3()])
@@ -214,7 +303,7 @@ function Band({ maxSpeed = 50, minSpeed = 0, isMobile = false }: BandProps) {
           >
             <mesh geometry={nodes.card.geometry}>
               <meshPhysicalMaterial
-                map={materials.base.map}
+                map={cardMap}
                 map-anisotropy={16}
                 clearcoat={isMobile ? 0 : 1}
                 clearcoatRoughness={0.15}


### PR DESCRIPTION
<html><head></head><body><h2>Summary</h2><p>When I was using the Lanyard component, I noticed that it was not very convenient to customize the card artwork and the lanyard band texture.</p><p>This PR adds new props for customizing the card's front face, back face, and band texture:</p><ul><li><p><code inline="">frontImage</code></p></li><li><p><code inline="">backImage</code></p></li><li><p><code inline="">imageFit</code></p></li><li><p><code inline="">lanyardImage</code></p></li><li><p><code inline="">lanyardWidth</code></p></li></ul><p>The front and back card images are rendered independently and preserve their original aspect ratio, so they will not be stretched or distorted. The lanyard band can also use a custom texture, with an adjustable width to give custom artwork more visible space.</p><h2>Motivation</h2><p>The card model uses a single texture atlas. The front face is UV-mapped to the left half of the texture, and the back face is UV-mapped to the right half.</p><p>Because of this, simply replacing the card material's <code inline="">map</code> with a custom image does not work correctly. The image can bleed across both sides of the card, or appear cropped and zoomed, because each face only samples part of the atlas.</p><p>This PR solves that by compositing the custom front and back images into the correct regions of the original texture atlas.</p><p>The lanyard band also benefits from more flexible customization. Custom band textures can now be passed in directly, and <code inline="">lanyardWidth</code> can be adjusted to give the artwork more room to display clearly.</p><h2><span>New Props</span></h2>
<table>
  <thead>
    <tr><th>Prop</th><th>Type</th><th>Default</th><th>Description</th></tr>
  </thead>
  <tbody>
    <tr><td><code>frontImage</code></td><td><code>string | null</code></td><td><code>null</code></td><td>Image URL for the card's front face.</td></tr>
    <tr><td><code>backImage</code></td><td><code>string | null</code></td><td><code>null</code></td><td>Image URL for the card's back face, rendered independently from the front.</td></tr>
    <tr><td><code>imageFit</code></td><td><code>'cover' | 'contain'</code></td><td><code>'cover'</code></td><td>How a custom card image fits its face. Both preserve aspect ratio — cover fills and crops, contain letterboxes.</td></tr>
    <tr><td><code>lanyardImage</code></td><td><code>string | null</code></td><td><code>null</code></td><td>Image URL for the lanyard band's texture.</td></tr>
    <tr><td><code>lanyardWidth</code></td><td><code>number</code></td><td><code>1</code></td><td>Width of the lanyard band. Increase it to give custom band artwork more room and reduce stretching.</td></tr>
  </tbody>
</table>
<h2>Example</h2><pre><code class="language-jsx">&lt;Lanyard
  position={[0, 0, 20]}
  gravity={[0, -40, 0]}
  frontImage="/avatar.png"
  backImage="/company-logo.png"
  imageFit="cover"
  lanyardImage="/band.png"
  lanyardWidth={1.8}
/&gt;
</code></pre><h2>How It Works</h2><p>For the card, the front and back UV regions were measured from <code inline="">card.glb</code>. The front face uses the left half of the texture, and the back face uses the right half.</p><p>When <code inline="">frontImage</code> or <code inline="">backImage</code> is provided, the component creates a new <code inline="">CanvasTexture</code> at the atlas resolution. It first draws the original baked texture, preserving the card edges and any untouched areas. Then it draws each custom image into its corresponding region of the atlas.</p><p>The card images are drawn with aspect-ratio preserving behavior:</p><ul><li><p><code inline="">cover</code> fills the target area and may crop part of the image.</p></li><li><p><code inline="">contain</code> keeps the full image visible and may leave empty space.</p></li></ul><p>For the lanyard band, <code inline="">lanyardImage</code> is used as the band texture, and <code inline="">lanyardWidth</code> controls the visual width of the band.</p><h2>Backwards Compatibility</h2><p>This change does not affect existing usage.</p><p>If no custom card image is provided, the component keeps using the original baked card texture. <code inline="">lanyardWidth</code> also defaults to <code inline="">1</code>, so the existing demo should render the same as before.</p><h2>Notes</h2><ul><li><p>Card and band images should use raster formats such as PNG or JPG.</p></li><li><p>SVG images may not work reliably when drawn onto a canvas, so they may be skipped.</p></li><li><p>The changes have been applied consistently across all four variants: JS/CSS, JS/Tailwind, TS/CSS, and TS/Tailwind.</p></li><li><p>The demo prop table and usage snippet have also been updated.</p></li></ul><h2>Commits</h2><p>The changes are split into separate commits for easier review.
It's currently working fine in my own project.

If you have any better suggestions for this feature, please let me know, and I will continue to make changes. Thank you.</p></body></html>


https://github.com/user-attachments/assets/970fc1e5-59c2-4d5b-a2d8-ba115d223ea7

