### PR TITLE
fix(Carousel): make slide indicators keyboard accessible

### DIFF
--- a/src/content/Components/Carousel/Carousel.css
+++ b/src/content/Components/Carousel/Carousel.css
@@ -121,9 +121,17 @@
 .carousel-indicator {
   height: 8px;
   width: 8px;
+  border: none;
+  padding: 0;
+  appearance: none;
   border-radius: 50%;
   cursor: pointer;
   transition: background-color 150ms;
+}
+
+.carousel-indicator:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 2px;
 }
 
 .carousel-indicator.active {

--- a/src/content/Components/Carousel/Carousel.jsx
+++ b/src/content/Components/Carousel/Carousel.jsx
@@ -245,9 +245,12 @@ export default function Carousel({
       <div className={`carousel-indicators-container ${round ? 'round' : ''}`}>
         <div className="carousel-indicators">
           {items.map((_, index) => (
-            <motion.div
+            <motion.button
+              type="button"
               key={index}
               className={`carousel-indicator ${activeIndex === index ? 'active' : 'inactive'}`}
+              aria-label={`Go to slide ${index + 1}`}
+              aria-current={activeIndex === index}
               animate={{
                 scale: activeIndex === index ? 1.2 : 1
               }}

--- a/src/tailwind/Components/Carousel/Carousel.jsx
+++ b/src/tailwind/Components/Carousel/Carousel.jsx
@@ -251,9 +251,12 @@ export default function Carousel({
       <div className={`flex w-full justify-center ${round ? 'absolute z-20 bottom-12 left-1/2 -translate-x-1/2' : ''}`}>
         <div className="mt-4 flex w-[150px] justify-between px-8">
           {items.map((_, index) => (
-            <motion.div
+            <motion.button
+              type="button"
               key={index}
-              className={`h-2 w-2 rounded-full cursor-pointer transition-colors duration-150 ${
+              aria-label={`Go to slide ${index + 1}`}
+              aria-current={activeIndex === index}
+              className={`h-2 w-2 rounded-full cursor-pointer border-0 p-0 appearance-none transition-colors duration-150 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white ${
                 activeIndex === index
                   ? round
                     ? 'bg-white'

--- a/src/ts-default/Components/Carousel/Carousel.css
+++ b/src/ts-default/Components/Carousel/Carousel.css
@@ -121,9 +121,17 @@
 .carousel-indicator {
   height: 8px;
   width: 8px;
+  border: none;
+  padding: 0;
+  appearance: none;
   border-radius: 50%;
   cursor: pointer;
   transition: background-color 150ms;
+}
+
+.carousel-indicator:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 2px;
 }
 
 .carousel-indicator.active {

--- a/src/ts-default/Components/Carousel/Carousel.tsx
+++ b/src/ts-default/Components/Carousel/Carousel.tsx
@@ -271,9 +271,12 @@ export default function Carousel({
       <div className={`carousel-indicators-container ${round ? 'round' : ''}`}>
         <div className="carousel-indicators">
           {items.map((_, index) => (
-            <motion.div
+            <motion.button
+              type="button"
               key={index}
               className={`carousel-indicator ${activeIndex === index ? 'active' : 'inactive'}`}
+              aria-label={`Go to slide ${index + 1}`}
+              aria-current={activeIndex === index}
               animate={{
                 scale: activeIndex === index ? 1.2 : 1
               }}

--- a/src/ts-tailwind/Components/Carousel/Carousel.tsx
+++ b/src/ts-tailwind/Components/Carousel/Carousel.tsx
@@ -279,9 +279,12 @@ export default function Carousel({
       <div className={`flex w-full justify-center ${round ? 'absolute z-20 bottom-12 left-1/2 -translate-x-1/2' : ''}`}>
         <div className="mt-4 flex w-[150px] justify-between px-8">
           {items.map((_, index) => (
-            <motion.div
+            <motion.button
+              type="button"
               key={index}
-              className={`h-2 w-2 rounded-full cursor-pointer transition-colors duration-150 ${
+              aria-label={`Go to slide ${index + 1}`}
+              aria-current={activeIndex === index}
+              className={`h-2 w-2 rounded-full cursor-pointer border-0 p-0 appearance-none transition-colors duration-150 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white ${
                 activeIndex === index
                   ? round
                     ? 'bg-white'


### PR DESCRIPTION
## Summary

Fixes #976. The Carousel slide indicators were rendered as `<motion.div>` elements with only an `onClick` handler, so keyboard-only users could neither focus them with **Tab** nor activate them with **Enter/Space**.

This switches the indicators to native `<motion.button type="button">`, which is focusable and Enter/Space-activatable for free, and adds the supporting a11y semantics:

- `aria-label="Go to slide N"` — screen readers now announce each control (previously empty `<div>`)
- `aria-current` — exposes which slide is active
- button resets (`border`/`padding`/`appearance` in CSS variants, `border-0 p-0 appearance-none` in Tailwind variants) — keep the dot styling identical
- a `:focus-visible` outline — keyboard focus is now visible (no outline on mouse click)

Mouse, drag and touch behaviour are unchanged.

Updated across all **4 variants** (JS/TS × CSS/Tailwind), per the contributing guidelines.

## How it was tested

Ran the demo locally (`/components/carousel`) and verified in a real browser:

| Check | Result |
|---|---|
| Indicators are `<button>` with `type="button"`, `aria-label`, `aria-current` | ✅ |
| Tab focuses each indicator in order (slide 1 → 2 → 3 → 4) | ✅ |
| Enter on a focused indicator changes the slide | ✅ |
| Space on a focused indicator changes the slide | ✅ |
| `:focus-visible` shows a 2px outline on keyboard focus, none on mouse click | ✅ |

The focus-visible outline style follows the existing convention in the repo (e.g. `LogoLoop`, `GlassSurface`).

> Note: registry artifacts under `public/r/` are not included, matching how prior component PRs (e.g. #977) leave registry regeneration to the maintainer build.