### PR TITLE
feat(CircularGallery): add keyboard navigation support

### DIFF
--- a/src/content/Components/CircularGallery/CircularGallery.css
+++ b/src/content/Components/CircularGallery/CircularGallery.css
@@ -8,3 +8,8 @@
 .circular-gallery:active {
   cursor: grabbing;
 }
+
+.circular-gallery:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 4px;
+}

--- a/src/content/Components/CircularGallery/CircularGallery.jsx
+++ b/src/content/Components/CircularGallery/CircularGallery.jsx
@@ -488,6 +488,31 @@ class App {
     this.scroll.target += (delta > 0 ? this.scrollSpeed : -this.scrollSpeed) * 0.2;
     this.onCheckDebounce();
   }
+  onKeyDown(e) {
+    switch (e.key) {
+      case 'ArrowRight':
+        e.preventDefault();
+        this.scroll.target += this.scrollSpeed * 5;
+        this.onCheckDebounce();
+        break;
+
+      case 'ArrowLeft':
+        e.preventDefault();
+        this.scroll.target -= this.scrollSpeed * 5;
+        this.onCheckDebounce();
+        break;
+
+      case 'Home':
+        e.preventDefault();
+        this.scroll.target = 0;
+        this.onCheckDebounce();
+        break;
+
+      default:
+        break;
+    }
+  }
+
   onCheck() {
     if (!this.medias || !this.medias[0]) return;
     const width = this.medias[0].width;
@@ -528,6 +553,8 @@ class App {
     this.boundOnTouchDown = this.onTouchDown.bind(this);
     this.boundOnTouchMove = this.onTouchMove.bind(this);
     this.boundOnTouchUp = this.onTouchUp.bind(this);
+    this.boundOnKeyDown = this.onKeyDown.bind(this);
+
     window.addEventListener('resize', this.boundOnResize);
     window.addEventListener('mousewheel', this.boundOnWheel);
     window.addEventListener('wheel', this.boundOnWheel);
@@ -537,6 +564,8 @@ class App {
     window.addEventListener('touchstart', this.boundOnTouchDown);
     window.addEventListener('touchmove', this.boundOnTouchMove);
     window.addEventListener('touchend', this.boundOnTouchUp);
+
+    this.container?.addEventListener('keydown', this.boundOnKeyDown);
   }
   destroy() {
     window.cancelAnimationFrame(this.raf);
@@ -551,6 +580,10 @@ class App {
     window.removeEventListener('touchend', this.boundOnTouchUp);
     if (this.renderer && this.renderer.gl && this.renderer.gl.canvas.parentNode) {
       this.renderer.gl.canvas.parentNode.removeChild(this.renderer.gl.canvas);
+    }
+
+    if (this.container) {
+      this.container.removeEventListener('keydown', this.boundOnKeyDown);
     }
   }
 }
@@ -582,10 +615,19 @@ export default function CircularGallery({
         scrollEase
       });
     });
+
     return () => {
       isMounted = false;
       if (app) app.destroy();
     };
   }, [items, bend, textColor, borderRadius, font, fontUrl, scrollSpeed, scrollEase]);
-  return <div className="circular-gallery" ref={containerRef} />;
+  return (
+    <div
+      className="circular-gallery"
+      ref={containerRef}
+      tabIndex={0}
+      role="region"
+      aria-label="Circular image gallery. Use left and right arrow keys to navigate."
+    />
+  );
 }

--- a/src/tailwind/Components/CircularGallery/CircularGallery.jsx
+++ b/src/tailwind/Components/CircularGallery/CircularGallery.jsx
@@ -486,6 +486,22 @@ class App {
     this.scroll.target += (delta > 0 ? this.scrollSpeed : -this.scrollSpeed) * 0.2;
     this.onCheckDebounce();
   }
+  onKeyDown(e) {
+    switch (e.key) {
+      case 'ArrowRight':
+        e.preventDefault();
+        this.scroll.target += this.scrollSpeed * 5;
+        this.onCheckDebounce();
+        break;
+      case 'ArrowLeft':
+        e.preventDefault();
+        this.scroll.target -= this.scrollSpeed * 5;
+        this.onCheckDebounce();
+        break;
+      default:
+        break;
+    }
+  }
   onCheck() {
     if (!this.medias || !this.medias[0]) return;
     const width = this.medias[0].width;
@@ -526,6 +542,7 @@ class App {
     this.boundOnTouchDown = this.onTouchDown.bind(this);
     this.boundOnTouchMove = this.onTouchMove.bind(this);
     this.boundOnTouchUp = this.onTouchUp.bind(this);
+    this.boundOnKeyDown = this.onKeyDown.bind(this);
     window.addEventListener('resize', this.boundOnResize);
     window.addEventListener('mousewheel', this.boundOnWheel);
     window.addEventListener('wheel', this.boundOnWheel);
@@ -535,6 +552,8 @@ class App {
     window.addEventListener('touchstart', this.boundOnTouchDown);
     window.addEventListener('touchmove', this.boundOnTouchMove);
     window.addEventListener('touchend', this.boundOnTouchUp);
+
+    this.container?.addEventListener('keydown', this.boundOnKeyDown);
   }
   destroy() {
     window.cancelAnimationFrame(this.raf);
@@ -549,6 +568,10 @@ class App {
     window.removeEventListener('touchend', this.boundOnTouchUp);
     if (this.renderer && this.renderer.gl && this.renderer.gl.canvas.parentNode) {
       this.renderer.gl.canvas.parentNode.removeChild(this.renderer.gl.canvas);
+    }
+
+    if (this.container) {
+      this.container.removeEventListener('keydown', this.boundOnKeyDown);
     }
   }
 }
@@ -585,5 +608,13 @@ export default function CircularGallery({
       if (app) app.destroy();
     };
   }, [items, bend, textColor, borderRadius, font, fontUrl, scrollSpeed, scrollEase]);
-  return <div className="w-full h-full overflow-hidden cursor-grab active:cursor-grabbing" ref={containerRef} />;
+  return (
+    <div
+      className="w-full h-full overflow-hidden cursor-grab active:cursor-grabbing focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4"
+      tabIndex={0}
+      role="region"
+      aria-label="Circular image gallery. Use Left and Right Arrow keys to navigate."
+      ref={containerRef}
+    />
+  );
 }

--- a/src/ts-default/Components/CircularGallery/CircularGallery.css
+++ b/src/ts-default/Components/CircularGallery/CircularGallery.css
@@ -8,3 +8,8 @@
 .circular-gallery:active {
   cursor: grabbing;
 }
+
+.circular-gallery:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 4px;
+}

--- a/src/ts-default/Components/CircularGallery/CircularGallery.tsx
+++ b/src/ts-default/Components/CircularGallery/CircularGallery.tsx
@@ -506,6 +506,7 @@ class App {
   boundOnTouchDown!: (e: MouseEvent | TouchEvent) => void;
   boundOnTouchMove!: (e: MouseEvent | TouchEvent) => void;
   boundOnTouchUp!: () => void;
+  boundOnKeyDown!: (e: KeyboardEvent) => void;
 
   isDown: boolean = false;
   start: number = 0;
@@ -669,6 +670,25 @@ class App {
     this.onCheckDebounce();
   }
 
+  onKeyDown(e: KeyboardEvent) {
+    switch (e.key) {
+      case 'ArrowRight':
+        e.preventDefault();
+        this.scroll.target += this.scrollSpeed * 5;
+        this.onCheckDebounce();
+        break;
+
+      case 'ArrowLeft':
+        e.preventDefault();
+        this.scroll.target -= this.scrollSpeed * 5;
+        this.onCheckDebounce();
+        break;
+
+      default:
+        break;
+    }
+  }
+
   onCheck() {
     if (!this.medias || !this.medias[0]) return;
     const width = this.medias[0].width;
@@ -712,6 +732,8 @@ class App {
     this.boundOnTouchDown = this.onTouchDown.bind(this);
     this.boundOnTouchMove = this.onTouchMove.bind(this);
     this.boundOnTouchUp = this.onTouchUp.bind(this);
+    this.boundOnKeyDown = this.onKeyDown.bind(this);
+
     window.addEventListener('resize', this.boundOnResize);
     window.addEventListener('mousewheel', this.boundOnWheel);
     window.addEventListener('wheel', this.boundOnWheel);
@@ -721,6 +743,8 @@ class App {
     window.addEventListener('touchstart', this.boundOnTouchDown);
     window.addEventListener('touchmove', this.boundOnTouchMove);
     window.addEventListener('touchend', this.boundOnTouchUp);
+
+    this.container?.addEventListener('keydown', this.boundOnKeyDown);
   }
 
   destroy() {
@@ -736,6 +760,9 @@ class App {
     window.removeEventListener('touchend', this.boundOnTouchUp);
     if (this.renderer && this.renderer.gl && this.renderer.gl.canvas.parentNode) {
       this.renderer.gl.canvas.parentNode.removeChild(this.renderer.gl.canvas as HTMLCanvasElement);
+    }
+    if (this.container) {
+      this.container.removeEventListener('keydown', this.boundOnKeyDown);
     }
   }
 }
@@ -783,5 +810,13 @@ export default function CircularGallery({
       if (app) app.destroy();
     };
   }, [items, bend, textColor, borderRadius, font, fontUrl, scrollSpeed, scrollEase]);
-  return <div className="circular-gallery" ref={containerRef} />;
+  return (
+    <div
+      className="circular-gallery"
+      ref={containerRef}
+      tabIndex={0}
+      role="region"
+      aria-label="Circular image gallery. Use Left and Right Arrow keys to navigate."
+    />
+  );
 }

--- a/src/ts-tailwind/Components/CircularGallery/CircularGallery.tsx
+++ b/src/ts-tailwind/Components/CircularGallery/CircularGallery.tsx
@@ -505,6 +505,7 @@ class App {
   boundOnTouchDown!: (e: MouseEvent | TouchEvent) => void;
   boundOnTouchMove!: (e: MouseEvent | TouchEvent) => void;
   boundOnTouchUp!: () => void;
+  boundOnKeyDown!: (e: KeyboardEvent) => void;
 
   isDown: boolean = false;
   start: number = 0;
@@ -668,6 +669,22 @@ class App {
     this.onCheckDebounce();
   }
 
+  onKeyDown(e: KeyboardEvent) {
+    switch (e.key) {
+      case 'ArrowRight':
+        e.preventDefault();
+        this.scroll.target += this.scrollSpeed * 5;
+        this.onCheckDebounce();
+        break;
+
+      case 'ArrowLeft':
+        e.preventDefault();
+        this.scroll.target -= this.scrollSpeed * 5;
+        this.onCheckDebounce();
+        break;
+    }
+  }
+
   onCheck() {
     if (!this.medias || !this.medias[0]) return;
     const width = this.medias[0].width;
@@ -711,6 +728,8 @@ class App {
     this.boundOnTouchDown = this.onTouchDown.bind(this);
     this.boundOnTouchMove = this.onTouchMove.bind(this);
     this.boundOnTouchUp = this.onTouchUp.bind(this);
+    this.boundOnKeyDown = this.onKeyDown.bind(this);
+
     window.addEventListener('resize', this.boundOnResize);
     window.addEventListener('mousewheel', this.boundOnWheel);
     window.addEventListener('wheel', this.boundOnWheel);
@@ -720,6 +739,12 @@ class App {
     window.addEventListener('touchstart', this.boundOnTouchDown);
     window.addEventListener('touchmove', this.boundOnTouchMove);
     window.addEventListener('touchend', this.boundOnTouchUp);
+
+    this.container?.addEventListener(
+      'keydown',
+
+      this.boundOnKeyDown
+    );
   }
 
   destroy() {
@@ -735,6 +760,13 @@ class App {
     window.removeEventListener('touchend', this.boundOnTouchUp);
     if (this.renderer && this.renderer.gl && this.renderer.gl.canvas.parentNode) {
       this.renderer.gl.canvas.parentNode.removeChild(this.renderer.gl.canvas as HTMLCanvasElement);
+    }
+    if (this.container) {
+      this.container.removeEventListener(
+        'keydown',
+
+        this.boundOnKeyDown
+      );
     }
   }
 }
@@ -782,5 +814,13 @@ export default function CircularGallery({
       if (app) app.destroy();
     };
   }, [items, bend, textColor, borderRadius, font, fontUrl, scrollSpeed, scrollEase]);
-  return <div className="w-full h-full overflow-hidden cursor-grab active:cursor-grabbing" ref={containerRef} />;
+  return (
+    <div
+      className="w-full h-full overflow-hidden cursor-grab active:cursor-grabbing"
+      ref={containerRef}
+      tabIndex={0}
+      role="region"
+      aria-label="Circular image gallery. Use Left and Right Arrow keys to navigate."
+    />
+  );
 }


### PR DESCRIPTION
Fixes #981. The CircularGallery component could only be navigated using mouse drag, touch gestures, and mouse wheel scrolling. Keyboard-only users could not interact with the gallery because it was not focusable and did not respond to keyboard input.

This adds keyboard navigation support and accessibility semantics:

- Added `ArrowLeft` and `ArrowRight` keyboard navigation.
- Added `tabIndex={0}` so the gallery can receive keyboard focus.
- Added `role="region"` and a descriptive `aria-label` for assistive technologies.
- Added keyboard event listener cleanup on component unmount.

Mouse, touch, drag, and wheel behaviour are unchanged.

Updated across all 4 variants (JS/TS × CSS/Tailwind), per the contributing guidelines.

## How it was tested

Ran the demo locally and verified in a real browser:

| Check | Result |
|--------|--------|
| Gallery receives focus via `Tab` | ✅ |
| `ArrowLeft` navigates to previous item | ✅ |
| `ArrowRight` navigates to next item | ✅ |
| Mouse drag interaction still works | ✅ |
| Mouse wheel interaction still works | ✅ |
| Touch interaction still works | ✅ |
| Keyboard event listeners are cleaned up on unmount | ✅ |

### Accessibility

- Keyboard-only users can now navigate the gallery.
- The component is focusable through normal tab navigation.
- Screen readers announce the gallery region using the provided `aria-label`.