### PR TITLE
feat(Folder): add keyboard navigation and accessibility support

### DIFF
--- a/src/content/Components/Folder/Folder.css
+++ b/src/content/Components/Folder/Folder.css
@@ -120,3 +120,9 @@
   transform-origin: bottom;
   transition: all 0.3s ease-in-out;
 }
+
+.folder:focus-visible {
+  outline: 2px solid #ffffff;
+  outline-offset: 4px;
+  border-radius: 10px;
+}

--- a/src/content/Components/Folder/Folder.jsx
+++ b/src/content/Components/Folder/Folder.jsx
@@ -76,7 +76,22 @@ const Folder = ({ color = '#5227FF', size = 1, items = [], className = '' }) => 
 
   return (
     <div style={scaleStyle} className={className}>
-      <div className={folderClassName} style={folderStyle} onClick={handleClick}>
+      <div
+        className={folderClassName}
+        style={folderStyle}
+        onClick={handleClick}
+        onKeyDown={e => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+
+            handleClick();
+          }
+        }}
+        tabIndex={0}
+        role="button"
+        aria-expanded={open}
+        aria-label={open ? 'Close folder' : 'Open folder'}
+      >
         <div className="folder__back">
           {papers.map((item, i) => (
             <div

--- a/src/tailwind/Components/Folder/Folder.jsx
+++ b/src/tailwind/Components/Folder/Folder.jsx
@@ -82,7 +82,7 @@ const Folder = ({ color = '#5227FF', size = 1, items = [], className = '' }) => 
   return (
     <div style={scaleStyle} className={className}>
       <div
-        className={`group relative transition-all duration-200 ease-in cursor-pointer ${
+        className={`group relative transition-all duration-200 ease-in cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 ${
           !open ? 'hover:-translate-y-2' : ''
         }`}
         style={{
@@ -90,6 +90,17 @@ const Folder = ({ color = '#5227FF', size = 1, items = [], className = '' }) => 
           transform: open ? 'translateY(-8px)' : undefined
         }}
         onClick={handleClick}
+        onKeyDown={e => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+
+            handleClick();
+          }
+        }}
+        tabIndex={0}
+        role="button"
+        aria-expanded={open}
+        aria-label={open ? 'Close folder' : 'Open folder'}
       >
         <div
           className="relative w-[100px] h-[80px] rounded-tl-0 rounded-tr-[10px] rounded-br-[10px] rounded-bl-[10px]"

--- a/src/ts-default/Components/Folder/Folder.css
+++ b/src/ts-default/Components/Folder/Folder.css
@@ -120,3 +120,9 @@
   transform-origin: bottom;
   transition: all 0.3s ease-in-out;
 }
+
+.folder:focus-visible {
+  outline: 2px solid #ffffff;
+  outline-offset: 4px;
+  border-radius: 10px;
+}

--- a/src/ts-default/Components/Folder/Folder.tsx
+++ b/src/ts-default/Components/Folder/Folder.tsx
@@ -85,7 +85,21 @@ const Folder: React.FC<FolderProps> = ({ color = '#5227FF', size = 1, items = []
 
   return (
     <div style={scaleStyle} className={className}>
-      <div className={folderClassName} style={folderStyle} onClick={handleClick}>
+      <div
+        className={folderClassName}
+        style={folderStyle}
+        onClick={handleClick}
+        onKeyDown={e => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            handleClick();
+          }
+        }}
+        tabIndex={0}
+        role="button"
+        aria-expanded={open}
+        aria-label={open ? 'Close folder' : 'Open folder'}
+      >
         <div className="folder__back">
           {papers.map((item, i) => (
             <div

--- a/src/ts-tailwind/Components/Folder/Folder.tsx
+++ b/src/ts-tailwind/Components/Folder/Folder.tsx
@@ -91,7 +91,7 @@ const Folder: React.FC<FolderProps> = ({ color = '#5227FF', size = 1, items = []
   return (
     <div style={scaleStyle} className={className}>
       <div
-        className={`group relative transition-all duration-200 ease-in cursor-pointer ${
+        className={`group relative transition-all duration-200 ease-in cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 ${
           !open ? 'hover:-translate-y-2' : ''
         }`}
         style={{
@@ -99,6 +99,16 @@ const Folder: React.FC<FolderProps> = ({ color = '#5227FF', size = 1, items = []
           transform: open ? 'translateY(-8px)' : undefined
         }}
         onClick={handleClick}
+        onKeyDown={e => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            handleClick();
+          }
+        }}
+        tabIndex={0}
+        role="button"
+        aria-expanded={open}
+        aria-label={open ? 'Close folder' : 'Open folder'}
       >
         <div
           className="relative w-[100px] h-[80px] rounded-tl-0 rounded-tr-[10px] rounded-br-[10px] rounded-bl-[10px]"


### PR DESCRIPTION
Fixes #988 

### Changes
- Added keyboard interaction using `Enter` and `Space` keys
- Added `tabIndex={0}` to make the folder focusable
- Added `role="button"` for semantic accessibility
- Added `aria-expanded` to communicate open/closed state
- Added dynamic `aria-label` ("Open folder" / "Close folder")
- Added visible focus indicator for keyboard users

Previously, the Folder component could only be interacted with using a mouse click. Keyboard users were unable to open or close the folder.

This update improves accessibility by allowing users to:
- Navigate to the component using the `Tab` key
- Toggle the folder using `Enter` or `Space`
- Receive proper state information through ARIA attributes
- Clearly identify the focused component

### Before

https://github.com/user-attachments/assets/ccba3fad-322f-431e-a5a4-e53a963b9cc2


- Mouse interaction only
- Not keyboard accessible
- No ARIA semantics

### After

https://github.com/user-attachments/assets/96c917f2-ba4d-4f4f-a0aa-4e99f5b7cabe


- Fully keyboard accessible
- Focusable with Tab
- Supports Enter and Space activation
- Includes appropriate ARIA attributes
- Visible focus state

