### PR TITLE
feat(CardNav): add keyboard support for hamburger menu

### DIFF
--- a/src/content/Components/CardNav/CardNav.jsx
+++ b/src/content/Components/CardNav/CardNav.jsx
@@ -140,8 +140,15 @@ const CardNav = ({
           <div
             className={`hamburger-menu ${isHamburgerOpen ? 'open' : ''}`}
             onClick={toggleMenu}
+            onKeyDown={e => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                toggleMenu();
+              }
+            }}
             role="button"
             aria-label={isExpanded ? 'Close menu' : 'Open menu'}
+            aria-expanded={isExpanded}
             tabIndex={0}
             style={{ color: menuColor || '#000' }}
           >

--- a/src/tailwind/Components/CardNav/CardNav.jsx
+++ b/src/tailwind/Components/CardNav/CardNav.jsx
@@ -145,8 +145,15 @@ const CardNav = ({
           <div
             className={`hamburger-menu ${isHamburgerOpen ? 'open' : ''} group h-full flex flex-col items-center justify-center cursor-pointer gap-[6px] order-2 md:order-none`}
             onClick={toggleMenu}
+            onKeyDown={e => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                toggleMenu();
+              }
+            }}
             role="button"
             aria-label={isExpanded ? 'Close menu' : 'Open menu'}
+            aria-expanded={isExpanded}
             tabIndex={0}
             style={{ color: menuColor || '#000' }}
           >

--- a/src/ts-default/Components/CardNav/CardNav.tsx
+++ b/src/ts-default/Components/CardNav/CardNav.tsx
@@ -163,8 +163,15 @@ const CardNav: React.FC<CardNavProps> = ({
           <div
             className={`hamburger-menu ${isHamburgerOpen ? 'open' : ''}`}
             onClick={toggleMenu}
+            onKeyDown={(e: React.KeyboardEvent<HTMLDivElement>) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                toggleMenu();
+              }
+            }}
             role="button"
             aria-label={isExpanded ? 'Close menu' : 'Open menu'}
+            aria-expanded={isExpanded}
             tabIndex={0}
             style={{ color: menuColor || '#000' }}
           >

--- a/src/ts-tailwind/Components/CardNav/CardNav.tsx
+++ b/src/ts-tailwind/Components/CardNav/CardNav.tsx
@@ -168,8 +168,15 @@ const CardNav: React.FC<CardNavProps> = ({
           <div
             className={`hamburger-menu ${isHamburgerOpen ? 'open' : ''} group h-full flex flex-col items-center justify-center cursor-pointer gap-[6px] order-2 md:order-none`}
             onClick={toggleMenu}
+            onKeyDown={(e: React.KeyboardEvent<HTMLDivElement>) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                toggleMenu();
+              }
+            }}
             role="button"
             aria-label={isExpanded ? 'Close menu' : 'Open menu'}
+            aria-expanded={isExpanded}
             tabIndex={0}
             style={{ color: menuColor || '#000' }}
           >


### PR DESCRIPTION
Fix #994 

### Summary

Adds keyboard accessibility support to the `CardNav` hamburger menu.

### Changes

- Added keyboard activation using `Enter` and `Space` keys

- Added `aria-expanded` to communicate menu state to assistive technologies

- Preserved existing mouse interaction behavior

- Improved accessibility for keyboard-only users

### Before

https://github.com/user-attachments/assets/167e12b6-b5c0-4313-bbb6-229ad51a8f05


The hamburger menu could receive keyboard focus via `tabIndex={0}`, but pressing `Enter` or `Space` did not toggle the navigation menu.

### After

https://github.com/user-attachments/assets/2d06de5f-5622-441c-8ff3-bfcc8c1e3382


The hamburger menu now supports:

- `Tab` to focus

- `Enter` to open/close the menu

- `Space` to open/close the menu

Additionally, the component exposes its state through `aria-expanded`.

### Why

Elements using `role="button"` should provide the same keyboard interactions users expect from native buttons. This change improves accessibility and keyboard navigation support.

## Files Changed

### Component Sources

- `src/content/Components/CardNav/CardNav.jsx`

- `src/tailwind/Components/CardNav/CardNav.jsx`

- `src/ts-default/Components/CardNav/CardNav.tsx`

- `src/ts-tailwind/Components/CardNav/CardNav.tsx`


### Testing

- [x] Focus hamburger menu using Tab

- [x] Press Enter to toggle menu

- [x] Press Space to toggle menu

- [x] Verify mouse interaction still works

- [x] Verify `aria-expanded` updates correctly
