### PR TITLE
fix(CircularText): remove debug console.log on hover

### DIFF
--- a/src/content/TextAnimations/CircularText/CircularText.jsx
+++ b/src/content/TextAnimations/CircularText/CircularText.jsx
@@ -37,7 +37,6 @@ const CircularText = ({ text, spinDuration = 20, onHover = 'speedUp', className 
 
   const handleHoverStart = () => {
     const start = rotation.get();
-    console.log('CircularText mounted with text:', text);
     if (!onHover) return;
 
     let transitionConfig;


### PR DESCRIPTION
Removes a leftover debug `console.log('CircularText mounted with text:', text)` from `handleHoverStart` in the JS-CSS variant of CircularText, closing #996.

The line fires on every `mouseenter` (despite the message saying "mounted") and pollutes the consumer's console in production. It exists **only** in the JS-CSS variant, the other three (JS-TW, TS-CSS, TS-TW) already have it removed, which leaves the four variants out of sync and breaks the `CONTRIBUTING.md` rule that every component change is reflected in all variants.

Deleted the single `console.log` line in `src/content/TextAnimations/CircularText/CircularText.jsx` (was line 40, inside `handleHoverStart`).

On `https://reactbits.dev/text-animations/circular-text`: before, hovering the rotating text logged once per `mouseenter`; after, the console stays clean on hover.
Confirmed via search that `console.log` is absent from the JS-TW, TS-CSS, and TS-TW variants of CircularText, so the four variants now match.
