### PR TITLE
FIX: Adjust UV coordinates for aspect ratio in shader

### DIFF
--- a/src/content/Backgrounds/DarkVeil/DarkVeil.jsx
+++ b/src/content/Backgrounds/DarkVeil/DarkVeil.jsx
@@ -59,6 +59,9 @@ vec4 cppn_fn(vec2 coordinate,float in0,float in1,float in2){
 
 void mainImage(out vec4 fragColor,in vec2 fragCoord){
     vec2 uv=fragCoord/uResolution.xy*2.-1.;
+    
+    uv.x *= uResolution.x / uResolution.y; 
+    
     uv.y*=-1.;
     uv+=uWarp*vec2(sin(uv.y*6.283+uTime*0.5),cos(uv.x*6.283+uTime*0.5))*0.05;
     fragColor=cppn_fn(uv,0.1*sin(0.3*uTime),0.1*sin(0.69*uTime),0.1*sin(0.44*uTime));


### PR DESCRIPTION
The effect used to get squashed on mobile devices; that should be fixed now.