### PR TITLE
fix: correctly parse 8-digit #RRGGBBAA hex colors

### DIFF
--- a/src/content/Animations/CursorGrid/CursorGrid.jsx
+++ b/src/content/Animations/CursorGrid/CursorGrid.jsx
@@ -10,7 +10,7 @@ const FALLOFF_CURVES = {
 const hexToRgb = hex => {
   const h = hex.replace('#', '');
   const v = h.length === 3 ? h.split('').map(c => c + c).join('') : h;
-  const num = parseInt(v, 16);
+  const num = parseInt(v.slice(0, 6), 16);
   return [(num >> 16) & 255, (num >> 8) & 255, num & 255];
 };
 

--- a/src/content/Animations/LaserFlow/LaserFlow.jsx
+++ b/src/content/Animations/LaserFlow/LaserFlow.jsx
@@ -282,7 +282,7 @@ export const LaserFlow = ({
         .split('')
         .map(x => x + x)
         .join('');
-    const n = parseInt(c, 16) || 0xffffff;
+    const n = parseInt(c.slice(0, 6), 16) || 0xffffff;
     return { r: ((n >> 16) & 255) / 255, g: ((n >> 8) & 255) / 255, b: (n & 255) / 255 };
   };
 

--- a/src/content/Backgrounds/FaultyTerminal/FaultyTerminal.jsx
+++ b/src/content/Backgrounds/FaultyTerminal/FaultyTerminal.jsx
@@ -215,7 +215,7 @@ function hexToRgb(hex) {
       .split('')
       .map(c => c + c)
       .join('');
-  const num = parseInt(h, 16);
+  const num = parseInt(h.slice(0, 6), 16);
   return [((num >> 16) & 255) / 255, ((num >> 8) & 255) / 255, (num & 255) / 255];
 }
 

--- a/src/content/Backgrounds/Particles/Particles.jsx
+++ b/src/content/Backgrounds/Particles/Particles.jsx
@@ -13,7 +13,7 @@ const hexToRgb = hex => {
       .map(c => c + c)
       .join('');
   }
-  const int = parseInt(hex, 16);
+  const int = parseInt(hex.slice(0, 6), 16);
   const r = ((int >> 16) & 255) / 255;
   const g = ((int >> 8) & 255) / 255;
   const b = (int & 255) / 255;

--- a/src/content/Backgrounds/PrismaticBurst/PrismaticBurst.jsx
+++ b/src/content/Backgrounds/PrismaticBurst/PrismaticBurst.jsx
@@ -184,7 +184,7 @@ const hexToRgb01 = hex => {
       b = h[2];
     h = r + r + g + g + b + b;
   }
-  const intVal = parseInt(h, 16);
+  const intVal = parseInt(h.slice(0, 6), 16);
   if (isNaN(intVal) || (h.length !== 6 && h.length !== 8)) return [1, 1, 1];
   const r = ((intVal >> 16) & 255) / 255;
   const g = ((intVal >> 8) & 255) / 255;

--- a/src/content/Components/Folder/Folder.jsx
+++ b/src/content/Components/Folder/Folder.jsx
@@ -9,7 +9,7 @@ const darkenColor = (hex, percent) => {
       .map(c => c + c)
       .join('');
   }
-  const num = parseInt(color, 16);
+  const num = parseInt(color.slice(0, 6), 16);
   let r = (num >> 16) & 0xff;
   let g = (num >> 8) & 0xff;
   let b = num & 0xff;

--- a/src/tailwind/Animations/CursorGrid/CursorGrid.jsx
+++ b/src/tailwind/Animations/CursorGrid/CursorGrid.jsx
@@ -9,7 +9,7 @@ const FALLOFF_CURVES = {
 const hexToRgb = hex => {
   const h = hex.replace('#', '');
   const v = h.length === 3 ? h.split('').map(c => c + c).join('') : h;
-  const num = parseInt(v, 16);
+  const num = parseInt(v.slice(0, 6), 16);
   return [(num >> 16) & 255, (num >> 8) & 255, num & 255];
 };
 

--- a/src/tailwind/Animations/ElectricBorder/ElectricBorder.jsx
+++ b/src/tailwind/Animations/ElectricBorder/ElectricBorder.jsx
@@ -9,7 +9,7 @@ function hexToRgba(hex, alpha = 1) {
       .map(c => c + c)
       .join('');
   }
-  const int = parseInt(h, 16);
+  const int = parseInt(h.slice(0, 6), 16);
   const r = (int >> 16) & 255;
   const g = (int >> 8) & 255;
   const b = int & 255;

--- a/src/tailwind/Animations/LaserFlow/LaserFlow.jsx
+++ b/src/tailwind/Animations/LaserFlow/LaserFlow.jsx
@@ -281,7 +281,7 @@ export const LaserFlow = ({
         .split('')
         .map(x => x + x)
         .join('');
-    const n = parseInt(c, 16) || 0xffffff;
+    const n = parseInt(c.slice(0, 6), 16) || 0xffffff;
     return { r: ((n >> 16) & 255) / 255, g: ((n >> 8) & 255) / 255, b: (n & 255) / 255 };
   };
 

--- a/src/tailwind/Backgrounds/FaultyTerminal/FaultyTerminal.jsx
+++ b/src/tailwind/Backgrounds/FaultyTerminal/FaultyTerminal.jsx
@@ -214,7 +214,7 @@ function hexToRgb(hex) {
       .split('')
       .map(c => c + c)
       .join('');
-  const num = parseInt(h, 16);
+  const num = parseInt(h.slice(0, 6), 16);
   return [((num >> 16) & 255) / 255, ((num >> 8) & 255) / 255, (num & 255) / 255];
 }
 

--- a/src/tailwind/Backgrounds/Particles/Particles.jsx
+++ b/src/tailwind/Backgrounds/Particles/Particles.jsx
@@ -11,7 +11,7 @@ const hexToRgb = hex => {
       .map(c => c + c)
       .join('');
   }
-  const int = parseInt(hex, 16);
+  const int = parseInt(hex.slice(0, 6), 16);
   const r = ((int >> 16) & 255) / 255;
   const g = ((int >> 8) & 255) / 255;
   const b = (int & 255) / 255;

--- a/src/tailwind/Backgrounds/PrismaticBurst/PrismaticBurst.jsx
+++ b/src/tailwind/Backgrounds/PrismaticBurst/PrismaticBurst.jsx
@@ -183,7 +183,7 @@ const hexToRgb01 = hex => {
       b = h[2];
     h = r + r + g + g + b + b;
   }
-  const intVal = parseInt(h, 16);
+  const intVal = parseInt(h.slice(0, 6), 16);
   if (isNaN(intVal) || (h.length !== 6 && h.length !== 8)) return [1, 1, 1];
   const r = ((intVal >> 16) & 255) / 255;
   const g = ((intVal >> 8) & 255) / 255;

--- a/src/tailwind/Components/Folder/Folder.jsx
+++ b/src/tailwind/Components/Folder/Folder.jsx
@@ -8,7 +8,7 @@ const darkenColor = (hex, percent) => {
       .map(c => c + c)
       .join('');
   }
-  const num = parseInt(color, 16);
+  const num = parseInt(color.slice(0, 6), 16);
   let r = (num >> 16) & 0xff;
   let g = (num >> 8) & 0xff;
   let b = num & 0xff;

--- a/src/ts-default/Animations/CursorGrid/CursorGrid.tsx
+++ b/src/ts-default/Animations/CursorGrid/CursorGrid.tsx
@@ -51,7 +51,7 @@ const FALLOFF_CURVES: Record<Falloff, (t: number) => number> = {
 const hexToRgb = (hex: string): [number, number, number] => {
   const h = hex.replace('#', '');
   const v = h.length === 3 ? h.split('').map(c => c + c).join('') : h;
-  const num = parseInt(v, 16);
+  const num = parseInt(v.slice(0, 6), 16);
   return [(num >> 16) & 255, (num >> 8) & 255, num & 255];
 };
 

--- a/src/ts-default/Animations/LaserFlow/LaserFlow.tsx
+++ b/src/ts-default/Animations/LaserFlow/LaserFlow.tsx
@@ -305,7 +305,7 @@ export const LaserFlow: React.FC<Props> = ({
         .split('')
         .map(x => x + x)
         .join('');
-    const n = parseInt(c, 16) || 0xffffff;
+    const n = parseInt(c.slice(0, 6), 16) || 0xffffff;
     return { r: ((n >> 16) & 255) / 255, g: ((n >> 8) & 255) / 255, b: (n & 255) / 255 };
   };
 

--- a/src/ts-default/Backgrounds/FaultyTerminal/FaultyTerminal.tsx
+++ b/src/ts-default/Backgrounds/FaultyTerminal/FaultyTerminal.tsx
@@ -238,7 +238,7 @@ function hexToRgb(hex: string): [number, number, number] {
       .split('')
       .map(c => c + c)
       .join('');
-  const num = parseInt(h, 16);
+  const num = parseInt(h.slice(0, 6), 16);
   return [((num >> 16) & 255) / 255, ((num >> 8) & 255) / 255, (num & 255) / 255];
 }
 

--- a/src/ts-default/Backgrounds/Particles/Particles.tsx
+++ b/src/ts-default/Backgrounds/Particles/Particles.tsx
@@ -29,7 +29,7 @@ const hexToRgb = (hex: string): [number, number, number] => {
       .map(c => c + c)
       .join('');
   }
-  const int = parseInt(hex, 16);
+  const int = parseInt(hex.slice(0, 6), 16);
   const r = ((int >> 16) & 255) / 255;
   const g = ((int >> 8) & 255) / 255;
   const b = (int & 255) / 255;

--- a/src/ts-default/Backgrounds/PrismaticBurst/PrismaticBurst.tsx
+++ b/src/ts-default/Backgrounds/PrismaticBurst/PrismaticBurst.tsx
@@ -200,7 +200,7 @@ const hexToRgb01 = (hex: string): [number, number, number] => {
       b = h[2];
     h = r + r + g + g + b + b;
   }
-  const intVal = parseInt(h, 16);
+  const intVal = parseInt(h.slice(0, 6), 16);
   if (isNaN(intVal) || (h.length !== 6 && h.length !== 8)) return [1, 1, 1];
   const r = ((intVal >> 16) & 255) / 255;
   const g = ((intVal >> 8) & 255) / 255;

--- a/src/ts-default/Components/Folder/Folder.tsx
+++ b/src/ts-default/Components/Folder/Folder.tsx
@@ -16,7 +16,7 @@ const darkenColor = (hex: string, percent: number): string => {
       .map(c => c + c)
       .join('');
   }
-  const num = parseInt(color, 16);
+  const num = parseInt(color.slice(0, 6), 16);
   let r = (num >> 16) & 0xff;
   let g = (num >> 8) & 0xff;
   let b = num & 0xff;

--- a/src/ts-tailwind/Animations/CursorGrid/CursorGrid.tsx
+++ b/src/ts-tailwind/Animations/CursorGrid/CursorGrid.tsx
@@ -50,7 +50,7 @@ const FALLOFF_CURVES: Record<Falloff, (t: number) => number> = {
 const hexToRgb = (hex: string): [number, number, number] => {
   const h = hex.replace('#', '');
   const v = h.length === 3 ? h.split('').map(c => c + c).join('') : h;
-  const num = parseInt(v, 16);
+  const num = parseInt(v.slice(0, 6), 16);
   return [(num >> 16) & 255, (num >> 8) & 255, num & 255];
 };
 

--- a/src/ts-tailwind/Animations/ElectricBorder/ElectricBorder.tsx
+++ b/src/ts-tailwind/Animations/ElectricBorder/ElectricBorder.tsx
@@ -9,7 +9,7 @@ function hexToRgba(hex: string, alpha: number = 1): string {
       .map(c => c + c)
       .join('');
   }
-  const int = parseInt(h, 16);
+  const int = parseInt(h.slice(0, 6), 16);
   const r = (int >> 16) & 255;
   const g = (int >> 8) & 255;
   const b = int & 255;

--- a/src/ts-tailwind/Animations/LaserFlow/LaserFlow.tsx
+++ b/src/ts-tailwind/Animations/LaserFlow/LaserFlow.tsx
@@ -268,7 +268,7 @@ function hexToRGB(hex: string) {
       .split('')
       .map(x => x + x)
       .join('');
-  const n = parseInt(c, 16) || 0xffffff;
+  const n = parseInt(c.slice(0, 6), 16) || 0xffffff;
   return { r: ((n >> 16) & 255) / 255, g: ((n >> 8) & 255) / 255, b: (n & 255) / 255 };
 }
 

--- a/src/ts-tailwind/Backgrounds/FaultyTerminal/FaultyTerminal.tsx
+++ b/src/ts-tailwind/Backgrounds/FaultyTerminal/FaultyTerminal.tsx
@@ -237,7 +237,7 @@ function hexToRgb(hex: string): [number, number, number] {
       .split('')
       .map(c => c + c)
       .join('');
-  const num = parseInt(h, 16);
+  const num = parseInt(h.slice(0, 6), 16);
   return [((num >> 16) & 255) / 255, ((num >> 8) & 255) / 255, (num & 255) / 255];
 }
 

--- a/src/ts-tailwind/Backgrounds/Particles/Particles.tsx
+++ b/src/ts-tailwind/Backgrounds/Particles/Particles.tsx
@@ -27,7 +27,7 @@ const hexToRgb = (hex: string): [number, number, number] => {
       .map(c => c + c)
       .join('');
   }
-  const int = parseInt(hex, 16);
+  const int = parseInt(hex.slice(0, 6), 16);
   const r = ((int >> 16) & 255) / 255;
   const g = ((int >> 8) & 255) / 255;
   const b = (int & 255) / 255;

--- a/src/ts-tailwind/Backgrounds/PrismaticBurst/PrismaticBurst.tsx
+++ b/src/ts-tailwind/Backgrounds/PrismaticBurst/PrismaticBurst.tsx
@@ -199,7 +199,7 @@ const hexToRgb01 = (hex: string): [number, number, number] => {
       b = h[2];
     h = r + r + g + g + b + b;
   }
-  const intVal = parseInt(h, 16);
+  const intVal = parseInt(h.slice(0, 6), 16);
   if (isNaN(intVal) || (h.length !== 6 && h.length !== 8)) return [1, 1, 1];
   const r = ((intVal >> 16) & 255) / 255;
   const g = ((intVal >> 8) & 255) / 255;

--- a/src/ts-tailwind/Components/Folder/Folder.tsx
+++ b/src/ts-tailwind/Components/Folder/Folder.tsx
@@ -15,7 +15,7 @@ const darkenColor = (hex: string, percent: number): string => {
       .map(c => c + c)
       .join('');
   }
-  const num = parseInt(color, 16);
+  const num = parseInt(color.slice(0, 6), 16);
   let r = (num >> 16) & 0xff;
   let g = (num >> 8) & 0xff;
   let b = num & 0xff;


### PR DESCRIPTION
Hex-to-RGB helpers that use `parseInt(fullHex, 16)` with bit shifts incorrectly parse 8-digit hex colors (`#RRGGBBAA`).

The alpha channel is treated as part of the RGB value, causing the color to be shifted (e.g. `#FF0000FF` is parsed as `(0, 0, 255)` instead of `(255, 0, 0)`).

This can happen when users paste colors from design tools or color pickers that export colors in the `#RRGGBBAA` format.

Fix:
Parse only the first 6 digits using `.slice(0, 6)`, following the same approach used in `CurvedInput`. The alpha channel is ignored, while the RGB values are parsed correctly.

Updated components (all variants):
- PrismaticBurst
- FaultyTerminal
- LaserFlow
- CursorGrid
- Particles
- Folder
- ElectricBorder

Thanks to @yceffort for spotting this issue during review.