### PR TITLE
fix: guard render-time window/matchMedia access for SSR (DecayCard, PixelCard, Masonry)

### DIFF
--- a/src/content/Components/DecayCard/DecayCard.jsx
+++ b/src/content/Components/DecayCard/DecayCard.jsx
@@ -16,9 +16,15 @@ const DecayCard = ({
 }) => {
   const svgRef = useRef(null);
   const displacementMapRef = useRef(null);
-  const cursor = useRef({ x: window.innerWidth / 2, y: window.innerHeight / 2 });
+  const cursor = useRef({
+    x: typeof window !== 'undefined' ? window.innerWidth / 2 : 0,
+    y: typeof window !== 'undefined' ? window.innerHeight / 2 : 0
+  });
   const cachedCursor = useRef({ ...cursor.current });
-  const winsize = useRef({ width: window.innerWidth, height: window.innerHeight });
+  const winsize = useRef({
+    width: typeof window !== 'undefined' ? window.innerWidth : 0,
+    height: typeof window !== 'undefined' ? window.innerHeight : 0
+  });
 
   useEffect(() => {
     const lerp = (a, b, n) => (1 - n) * a + n * b;

--- a/src/content/Components/Masonry/Masonry.jsx
+++ b/src/content/Components/Masonry/Masonry.jsx
@@ -4,7 +4,10 @@ import { gsap } from 'gsap';
 import './Masonry.css';
 
 const useMedia = (queries, values, defaultValue) => {
-  const get = () => values[queries.findIndex(q => matchMedia(q).matches)] ?? defaultValue;
+  const get = () => {
+    if (typeof window === 'undefined') return defaultValue;
+    return values[queries.findIndex(q => matchMedia(q).matches)] ?? defaultValue;
+  };
 
   const [value, setValue] = useState(get);
 

--- a/src/content/Components/PixelCard/PixelCard.jsx
+++ b/src/content/Components/PixelCard/PixelCard.jsx
@@ -128,7 +128,9 @@ export default function PixelCard({ variant = 'default', gap, speed, colors, noF
   const pixelsRef = useRef([]);
   const animationRef = useRef(null);
   const timePreviousRef = useRef(performance.now());
-  const reducedMotion = useRef(window.matchMedia('(prefers-reduced-motion: reduce)').matches).current;
+  const reducedMotion = useRef(
+    typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  ).current;
 
   const variantCfg = VARIANTS[variant] || VARIANTS.default;
   const finalGap = gap ?? variantCfg.gap;

--- a/src/tailwind/Components/DecayCard/DecayCard.jsx
+++ b/src/tailwind/Components/DecayCard/DecayCard.jsx
@@ -14,9 +14,15 @@ const DecayCard = ({
 }) => {
   const svgRef = useRef(null);
   const displacementMapRef = useRef(null);
-  const cursor = useRef({ x: window.innerWidth / 2, y: window.innerHeight / 2 });
+  const cursor = useRef({
+    x: typeof window !== 'undefined' ? window.innerWidth / 2 : 0,
+    y: typeof window !== 'undefined' ? window.innerHeight / 2 : 0
+  });
   const cachedCursor = useRef({ ...cursor.current });
-  const winsize = useRef({ width: window.innerWidth, height: window.innerHeight });
+  const winsize = useRef({
+    width: typeof window !== 'undefined' ? window.innerWidth : 0,
+    height: typeof window !== 'undefined' ? window.innerHeight : 0
+  });
 
   useEffect(() => {
     const lerp = (a, b, n) => (1 - n) * a + n * b;

--- a/src/tailwind/Components/Masonry/Masonry.jsx
+++ b/src/tailwind/Components/Masonry/Masonry.jsx
@@ -2,7 +2,10 @@ import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { gsap } from 'gsap';
 
 const useMedia = (queries, values, defaultValue) => {
-  const get = () => values[queries.findIndex(q => matchMedia(q).matches)] ?? defaultValue;
+  const get = () => {
+    if (typeof window === 'undefined') return defaultValue;
+    return values[queries.findIndex(q => matchMedia(q).matches)] ?? defaultValue;
+  };
 
   const [value, setValue] = useState(get);
 

--- a/src/tailwind/Components/PixelCard/PixelCard.jsx
+++ b/src/tailwind/Components/PixelCard/PixelCard.jsx
@@ -127,7 +127,9 @@ export default function PixelCard({ variant = 'default', gap, speed, colors, noF
   const pixelsRef = useRef([]);
   const animationRef = useRef(null);
   const timePreviousRef = useRef(performance.now());
-  const reducedMotion = useRef(window.matchMedia('(prefers-reduced-motion: reduce)').matches).current;
+  const reducedMotion = useRef(
+    typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  ).current;
 
   const variantCfg = VARIANTS[variant] || VARIANTS.default;
   const finalGap = gap ?? variantCfg.gap;

--- a/src/ts-default/Components/DecayCard/DecayCard.tsx
+++ b/src/ts-default/Components/DecayCard/DecayCard.tsx
@@ -28,13 +28,13 @@ const DecayCard: React.FC<DecayCardProps> = ({
   const svgRef = useRef<HTMLDivElement>(null);
   const displacementMapRef = useRef<SVGFEDisplacementMapElement>(null);
   const cursor = useRef<{ x: number; y: number }>({
-    x: window.innerWidth / 2,
-    y: window.innerHeight / 2
+    x: typeof window !== 'undefined' ? window.innerWidth / 2 : 0,
+    y: typeof window !== 'undefined' ? window.innerHeight / 2 : 0
   });
   const cachedCursor = useRef<{ x: number; y: number }>({ ...cursor.current });
   const winsize = useRef<{ width: number; height: number }>({
-    width: window.innerWidth,
-    height: window.innerHeight
+    width: typeof window !== 'undefined' ? window.innerWidth : 0,
+    height: typeof window !== 'undefined' ? window.innerHeight : 0
   });
 
   useEffect(() => {

--- a/src/ts-default/Components/Masonry/Masonry.tsx
+++ b/src/ts-default/Components/Masonry/Masonry.tsx
@@ -4,7 +4,10 @@ import { gsap } from 'gsap';
 import './Masonry.css';
 
 const useMedia = (queries: string[], values: number[], defaultValue: number): number => {
-  const get = () => values[queries.findIndex(q => matchMedia(q).matches)] ?? defaultValue;
+  const get = () => {
+    if (typeof window === 'undefined') return defaultValue;
+    return values[queries.findIndex(q => matchMedia(q).matches)] ?? defaultValue;
+  };
 
   const [value, setValue] = useState<number>(get);
 

--- a/src/ts-default/Components/PixelCard/PixelCard.tsx
+++ b/src/ts-default/Components/PixelCard/PixelCard.tsx
@@ -181,7 +181,9 @@ export default function PixelCard({
   const pixelsRef = useRef<Pixel[]>([]);
   const animationRef = useRef<ReturnType<typeof requestAnimationFrame> | null>(null);
   const timePreviousRef = useRef(performance.now());
-  const reducedMotion = useRef(window.matchMedia('(prefers-reduced-motion: reduce)').matches).current;
+  const reducedMotion = useRef(
+    typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  ).current;
 
   const variantCfg: VariantConfig = VARIANTS[variant] || VARIANTS.default;
   const finalGap = gap ?? variantCfg.gap;

--- a/src/ts-tailwind/Components/DecayCard/DecayCard.tsx
+++ b/src/ts-tailwind/Components/DecayCard/DecayCard.tsx
@@ -27,13 +27,13 @@ const DecayCard: React.FC<DecayCardProps> = ({
   const svgRef = useRef<HTMLDivElement | null>(null);
   const displacementMapRef = useRef<SVGFEDisplacementMapElement | null>(null);
   const cursor = useRef<{ x: number; y: number }>({
-    x: window.innerWidth / 2,
-    y: window.innerHeight / 2
+    x: typeof window !== 'undefined' ? window.innerWidth / 2 : 0,
+    y: typeof window !== 'undefined' ? window.innerHeight / 2 : 0
   });
   const cachedCursor = useRef<{ x: number; y: number }>({ ...cursor.current });
   const winsize = useRef<{ width: number; height: number }>({
-    width: window.innerWidth,
-    height: window.innerHeight
+    width: typeof window !== 'undefined' ? window.innerWidth : 0,
+    height: typeof window !== 'undefined' ? window.innerHeight : 0
   });
 
   useEffect(() => {

--- a/src/ts-tailwind/Components/Masonry/Masonry.tsx
+++ b/src/ts-tailwind/Components/Masonry/Masonry.tsx
@@ -2,7 +2,10 @@ import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 're
 import { gsap } from 'gsap';
 
 const useMedia = (queries: string[], values: number[], defaultValue: number): number => {
-  const get = () => values[queries.findIndex(q => matchMedia(q).matches)] ?? defaultValue;
+  const get = () => {
+    if (typeof window === 'undefined') return defaultValue;
+    return values[queries.findIndex(q => matchMedia(q).matches)] ?? defaultValue;
+  };
 
   const [value, setValue] = useState<number>(get);
 

--- a/src/ts-tailwind/Components/PixelCard/PixelCard.tsx
+++ b/src/ts-tailwind/Components/PixelCard/PixelCard.tsx
@@ -180,7 +180,9 @@ export default function PixelCard({
   const pixelsRef = useRef<Pixel[]>([]);
   const animationRef = useRef<ReturnType<typeof requestAnimationFrame> | null>(null);
   const timePreviousRef = useRef(performance.now());
-  const reducedMotion = useRef(window.matchMedia('(prefers-reduced-motion: reduce)').matches).current;
+  const reducedMotion = useRef(
+    typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  ).current;
 
   const variantCfg: VariantConfig = VARIANTS[variant] || VARIANTS.default;
   const finalGap = gap ?? variantCfg.gap;


### PR DESCRIPTION
## Problem

`DecayCard`, `PixelCard` and `Masonry` access browser globals **during render** (in `useRef` / `useState` initializers), so they throw under SSR (e.g. Next.js, or any `renderToString` environment) before the component ever mounts:

```
ReferenceError: window is not defined
```

Same class of bug fixed for `TargetCursor` in #911; I've reused the same `typeof window` guard style.

## Changes

Guarded only the **render-time** accesses — effect/handler code is untouched.

- **DecayCard** — the `cursor` and `winsize` `useRef` initializers read `window.innerWidth/innerHeight`. Guarded with `typeof window !== 'undefined' ? … : 0`. The existing resize/mousemove effect overwrites these on mount, so client behavior is unchanged.
- **PixelCard** — `reducedMotion = useRef(window.matchMedia(...).matches)` runs at render. Guarded with `typeof window !== 'undefined' && …` (→ `false` on the server, i.e. motion not reduced).
- **Masonry** — `useMedia`'s `get()` is passed to `useState(get)`, so it runs once during render and calls `matchMedia`. Added an early `if (typeof window === 'undefined') return defaultValue;`.

All three were updated across **all 4 variants** (JS-CSS, JS-TW, TS-CSS, TS-TW) per the contributing guide.

## Notes / testing

- No API or client-behavior changes; server-render safety only.
- Verified the changed files parse and are Prettier-clean (`prettier --check`).
- Scope kept tight: only components with **unguarded render-time** access. Others referencing `window` do so inside effects/handlers or already guard with `typeof window`, so they're SSR-safe and left as-is.
