### PR TITLE
fix: restart animation loop when stale requestAnimationFrame exists

### DIFF
--- a/src/content/Components/LineSidebar/LineSidebar.jsx
+++ b/src/content/Components/LineSidebar/LineSidebar.jsx
@@ -84,7 +84,10 @@ const LineSidebar = ({
   }, []);
 
   const startLoop = useCallback(() => {
-    if (rafRef.current != null) return;
+    if (rafRef.current != null) {
+      cancelAnimationFrame(rafRef.current);
+    }
+
     lastRef.current = performance.now();
     rafRef.current = requestAnimationFrame(runFrame);
   }, [runFrame]);

--- a/src/content/Components/OptionWheel/OptionWheel.jsx
+++ b/src/content/Components/OptionWheel/OptionWheel.jsx
@@ -128,7 +128,9 @@ const OptionWheel = ({
   }, []);
 
   const startLoop = useCallback(() => {
-    if (rafRef.current != null) return;
+    if (rafRef.current != null) {
+      cancelAnimationFrame(rafRef.current);
+    }
     lastRef.current = performance.now();
     rafRef.current = requestAnimationFrame(runFrame);
   }, [runFrame]);

--- a/src/tailwind/Components/LineSidebar/LineSidebar.jsx
+++ b/src/tailwind/Components/LineSidebar/LineSidebar.jsx
@@ -83,7 +83,9 @@ const LineSidebar = ({
   }, []);
 
   const startLoop = useCallback(() => {
-    if (rafRef.current != null) return;
+    if (rafRef.current != null) {
+      cancelAnimationFrame(rafRef.current);
+    }
     lastRef.current = performance.now();
     rafRef.current = requestAnimationFrame(runFrame);
   }, [runFrame]);

--- a/src/tailwind/Components/OptionWheel/OptionWheel.jsx
+++ b/src/tailwind/Components/OptionWheel/OptionWheel.jsx
@@ -127,7 +127,10 @@ const OptionWheel = ({
   }, []);
 
   const startLoop = useCallback(() => {
-    if (rafRef.current != null) return;
+    if (rafRef.current != null) {
+      cancelAnimationFrame(rafRef.current);
+    }
+
     lastRef.current = performance.now();
     rafRef.current = requestAnimationFrame(runFrame);
   }, [runFrame]);

--- a/src/tailwind/Components/OptionWheel/OptionWheel.jsx
+++ b/src/tailwind/Components/OptionWheel/OptionWheel.jsx
@@ -130,7 +130,6 @@ const OptionWheel = ({
     if (rafRef.current != null) {
       cancelAnimationFrame(rafRef.current);
     }
-
     lastRef.current = performance.now();
     rafRef.current = requestAnimationFrame(runFrame);
   }, [runFrame]);

--- a/src/ts-default/Components/LineSidebar/LineSidebar.tsx
+++ b/src/ts-default/Components/LineSidebar/LineSidebar.tsx
@@ -108,7 +108,9 @@ const LineSidebar = ({
   }, []);
 
   const startLoop = useCallback(() => {
-    if (rafRef.current != null) return;
+    if (rafRef.current != null) {
+      cancelAnimationFrame(rafRef.current);
+    }
     lastRef.current = performance.now();
     rafRef.current = requestAnimationFrame(runFrame);
   }, [runFrame]);

--- a/src/ts-default/Components/OptionWheel/OptionWheel.tsx
+++ b/src/ts-default/Components/OptionWheel/OptionWheel.tsx
@@ -170,7 +170,9 @@ const OptionWheel = ({
   }, []);
 
   const startLoop = useCallback(() => {
-    if (rafRef.current != null) return;
+    if (rafRef.current != null) {
+      cancelAnimationFrame(rafRef.current);
+    }
     lastRef.current = performance.now();
     rafRef.current = requestAnimationFrame(runFrame);
   }, [runFrame]);

--- a/src/ts-tailwind/Components/LineSidebar/LineSidebar.tsx
+++ b/src/ts-tailwind/Components/LineSidebar/LineSidebar.tsx
@@ -107,7 +107,9 @@ const LineSidebar = ({
   }, []);
 
   const startLoop = useCallback(() => {
-    if (rafRef.current != null) return;
+    if (rafRef.current != null) {
+      cancelAnimationFrame(rafRef.current);
+    }
     lastRef.current = performance.now();
     rafRef.current = requestAnimationFrame(runFrame);
   }, [runFrame]);

--- a/src/ts-tailwind/Components/OptionWheel/OptionWheel.tsx
+++ b/src/ts-tailwind/Components/OptionWheel/OptionWheel.tsx
@@ -169,7 +169,9 @@ const OptionWheel = ({
   }, []);
 
   const startLoop = useCallback(() => {
-    if (rafRef.current != null) return;
+    if (rafRef.current != null) {
+      cancelAnimationFrame(rafRef.current);
+    }
     lastRef.current = performance.now();
     rafRef.current = requestAnimationFrame(runFrame);
   }, [runFrame]);


### PR DESCRIPTION
## Summary

This PR fixes an animation loop issue affecting multiple components that use the same `requestAnimationFrame` scheduling pattern.

## Root Cause

The animation loop was guarded with:

```ts
if (rafRef.current != null) return;
```

If `rafRef.current` contained a previously scheduled animation frame ID, `startLoop()` exited early without scheduling a new frame. This could prevent the animation loop from restarting, causing interactive animations to stop responding.

## Fix

Restart the animation loop by cancelling any previously scheduled frame before requesting a new one.

```ts
const startLoop = useCallback(() => {
  if (rafRef.current != null) {
    cancelAnimationFrame(rafRef.current);
  }

  lastRef.current = performance.now();
  rafRef.current = requestAnimationFrame(runFrame);
}, [runFrame]);
```

## Components Updated

- OptionWheel
- LineSidebar

## Testing

Verified that the affected components correctly restart their animation loop and interactive animations (hover, selection, etc.) now work as expected.

Fixes #1014