### PR TITLE
fix: upgrade tar to 7.5.19 (CVE-2026-59873)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9164,9 +9164,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.2.tgz",
-      "integrity": "sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==",
+      "version": "7.5.19",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz",
+      "integrity": "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -73,5 +73,8 @@
     "tw-animate-css": "^1.4.0",
     "typescript": "^5.7.3",
     "vite": "^5.3.4"
+  },
+  "overrides": {
+    "tar": "7.5.19"
   }
 }


### PR DESCRIPTION
## Summary
Upgrade tar from 7.5.2 to 7.5.19 to fix CVE-2026-59873.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2026-59873 |
| **Severity** | CRITICAL |
| **Scanner** | trivy |
| **Rule** | `CVE-2026-59873` |
| **File** | `package-lock.json` |
| **Assessment** | Likely exploitable |

**Description**: tar: node-tar: Denial of Service via crafted gzip bomb

## Evidence

**Scanner confirmation**: trivy rule `CVE-2026-59873` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Changes
- `package.json`
- `package-lock.json`

## Behavior Preservation
The change is scoped to 2 files on the vulnerable path, and the project builds successfully with this change applied.

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
