### PR TITLE
fix(ts): use type-only imports in TS variants (fixes TS1484 in stock Vite react-ts apps)

### DIFF
--- a/src/ts-default/Animations/Crosshair/Crosshair.tsx
+++ b/src/ts-default/Animations/Crosshair/Crosshair.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, RefObject } from 'react';
+import React, { useEffect, useRef, type RefObject } from 'react';
 import { gsap } from 'gsap';
 
 const lerp = (a: number, b: number, n: number): number => (1 - n) * a + n * b;

--- a/src/ts-default/Animations/ElectricBorder/ElectricBorder.tsx
+++ b/src/ts-default/Animations/ElectricBorder/ElectricBorder.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useCallback, CSSProperties, ReactNode } from 'react';
+import React, { useEffect, useRef, useCallback, type CSSProperties, type ReactNode } from 'react';
 import './ElectricBorder.css';
 
 interface ElectricBorderProps {

--- a/src/ts-default/Animations/GradualBlur/GradualBlur.tsx
+++ b/src/ts-default/Animations/GradualBlur/GradualBlur.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, useEffect, useRef, useState, useMemo, PropsWithChildren } from 'react';
+import React, { type CSSProperties, useEffect, useRef, useState, useMemo, type PropsWithChildren } from 'react';
 
 import './GradualBlur.css';
 

--- a/src/ts-default/Animations/ImageTrail/ImageTrail.tsx
+++ b/src/ts-default/Animations/ImageTrail/ImageTrail.tsx
@@ -1,5 +1,5 @@
 import { gsap } from 'gsap';
-import { JSX, useEffect, useRef } from 'react';
+import { type JSX, useEffect, useRef } from 'react';
 import './ImageTrail.css';
 
 function lerp(a: number, b: number, n: number): number {

--- a/src/ts-default/Animations/Magnet/Magnet.tsx
+++ b/src/ts-default/Animations/Magnet/Magnet.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, ReactNode, HTMLAttributes } from 'react';
+import React, { useState, useEffect, useRef, type ReactNode, type HTMLAttributes } from 'react';
 
 interface MagnetProps extends HTMLAttributes<HTMLDivElement> {
   children: ReactNode;

--- a/src/ts-default/Animations/MagnetLines/MagnetLines.tsx
+++ b/src/ts-default/Animations/MagnetLines/MagnetLines.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, CSSProperties } from 'react';
+import React, { useRef, useEffect, type CSSProperties } from 'react';
 import './MagnetLines.css';
 
 interface MagnetLinesProps {

--- a/src/ts-default/Animations/OrbitImages/OrbitImages.tsx
+++ b/src/ts-default/Animations/OrbitImages/OrbitImages.tsx
@@ -1,7 +1,7 @@
 // Component created by Dominik Koch
 // https://x.com/dominikkoch
 
-import { useMemo, useEffect, useLayoutEffect, useRef, useState, ReactNode } from 'react';
+import { useMemo, useEffect, useLayoutEffect, useRef, useState, type ReactNode } from 'react';
 import { motion, useMotionValue, useTransform, animate, MotionValue } from 'motion/react';
 import './OrbitImages.css';
 

--- a/src/ts-default/Animations/PixelTrail/PixelTrail.tsx
+++ b/src/ts-default/Animations/PixelTrail/PixelTrail.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-unknown-property */
 import React, { useMemo } from 'react';
-import { Canvas, useThree, CanvasProps, ThreeEvent } from '@react-three/fiber';
+import { Canvas, useThree, type CanvasProps, type ThreeEvent } from '@react-three/fiber';
 import { shaderMaterial, useTrailTexture } from '@react-three/drei';
 import * as THREE from 'three';
 

--- a/src/ts-default/Animations/PixelTransition/PixelTransition.tsx
+++ b/src/ts-default/Animations/PixelTransition/PixelTransition.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, useState, CSSProperties } from 'react';
+import React, { useRef, useEffect, useState, type CSSProperties } from 'react';
 import { gsap } from 'gsap';
 import './PixelTransition.css';
 

--- a/src/ts-default/Animations/StickerPeel/StickerPeel.tsx
+++ b/src/ts-default/Animations/StickerPeel/StickerPeel.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useMemo, CSSProperties } from 'react';
+import { useRef, useEffect, useMemo, type CSSProperties } from 'react';
 import { gsap } from 'gsap';
 import { Draggable } from 'gsap/Draggable';
 import './StickerPeel.css';

--- a/src/ts-default/Animations/Strands/Strands.tsx
+++ b/src/ts-default/Animations/Strands/Strands.tsx
@@ -1,5 +1,5 @@
 import { Renderer, Program, Mesh, Color, Triangle, RenderTarget } from 'ogl';
-import { useEffect, useRef, CSSProperties } from 'react';
+import { useEffect, useRef, type CSSProperties } from 'react';
 
 import './Strands.css';
 

--- a/src/ts-default/Backgrounds/Ballpit/Ballpit.tsx
+++ b/src/ts-default/Backgrounds/Ballpit/Ballpit.tsx
@@ -22,7 +22,7 @@ import {
   Vector2,
   Vector3,
   WebGLRenderer,
-  WebGLRendererParameters
+  type WebGLRendererParameters
 } from 'three';
 import { RoomEnvironment } from 'three/examples/jsm/environments/RoomEnvironment.js';
 

--- a/src/ts-default/Backgrounds/Beams/Beams.tsx
+++ b/src/ts-default/Backgrounds/Beams/Beams.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useImperativeHandle, useEffect, useRef, useMemo, FC, ReactNode } from 'react';
+import { forwardRef, useImperativeHandle, useEffect, useRef, useMemo, type FC, type ReactNode } from 'react';
 
 import * as THREE from 'three';
 

--- a/src/ts-default/Backgrounds/Dither/Dither.tsx
+++ b/src/ts-default/Backgrounds/Dither/Dither.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-unknown-property */
 import { useRef, useEffect, forwardRef } from 'react';
-import { Canvas, useFrame, useThree, ThreeEvent } from '@react-three/fiber';
+import { Canvas, useFrame, useThree, type ThreeEvent } from '@react-three/fiber';
 import { EffectComposer, wrapEffect } from '@react-three/postprocessing';
 import { Effect } from 'postprocessing';
 import * as THREE from 'three';

--- a/src/ts-default/Backgrounds/GridMotion/GridMotion.tsx
+++ b/src/ts-default/Backgrounds/GridMotion/GridMotion.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, FC, ReactNode } from 'react';
+import { useEffect, useRef, type FC, type ReactNode } from 'react';
 import { gsap } from 'gsap';
 import './GridMotion.css';
 

--- a/src/ts-default/Backgrounds/Hyperspeed/Hyperspeed.tsx
+++ b/src/ts-default/Backgrounds/Hyperspeed/Hyperspeed.tsx
@@ -1,5 +1,5 @@
 import { BloomEffect, EffectComposer, EffectPass, RenderPass, SMAAEffect, SMAAPreset } from 'postprocessing';
-import { FC, useEffect, useRef } from 'react';
+import { type FC, useEffect, useRef } from 'react';
 import * as THREE from 'three';
 
 import './Hyperspeed.css';

--- a/src/ts-default/Backgrounds/Silk/Silk.tsx
+++ b/src/ts-default/Backgrounds/Silk/Silk.tsx
@@ -1,8 +1,8 @@
 /* eslint-disable react/no-unknown-property */
 import React, { forwardRef, useMemo, useRef, useLayoutEffect, useEffect } from 'react';
-import { Canvas, useFrame, useThree, RootState } from '@react-three/fiber';
+import { Canvas, useFrame, useThree, type RootState } from '@react-three/fiber';
 import { Color, Mesh, ShaderMaterial } from 'three';
-import { IUniform } from 'three';
+import { type IUniform } from 'three';
 
 type NormalizedRGB = [number, number, number];
 

--- a/src/ts-default/Backgrounds/Waves/Waves.tsx
+++ b/src/ts-default/Backgrounds/Waves/Waves.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, CSSProperties } from 'react';
+import React, { useRef, useEffect, type CSSProperties } from 'react';
 import './Waves.css';
 
 class Grad {

--- a/src/ts-default/Components/AnimatedList/AnimatedList.tsx
+++ b/src/ts-default/Components/AnimatedList/AnimatedList.tsx
@@ -1,4 +1,12 @@
-import React, { useRef, useState, useEffect, useCallback, ReactNode, MouseEventHandler, UIEvent } from 'react';
+import React, {
+  useRef,
+  useState,
+  useEffect,
+  useCallback,
+  type ReactNode,
+  type MouseEventHandler,
+  type UIEvent
+} from 'react';
 import { motion, useInView } from 'motion/react';
 import './AnimatedList.css';
 

--- a/src/ts-default/Components/CardSwap/CardSwap.tsx
+++ b/src/ts-default/Components/CardSwap/CardSwap.tsx
@@ -3,9 +3,9 @@ import React, {
   cloneElement,
   forwardRef,
   isValidElement,
-  ReactElement,
-  ReactNode,
-  RefObject,
+  type ReactElement,
+  type ReactNode,
+  type RefObject,
   useEffect,
   useMemo,
   useRef

--- a/src/ts-default/Components/Carousel/Carousel.tsx
+++ b/src/ts-default/Components/Carousel/Carousel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { motion, PanInfo, useMotionValue, useTransform } from 'motion/react';
+import { motion, type PanInfo, useMotionValue, useTransform } from 'motion/react';
 // replace icons with your own if needed
 import { FiCircle, FiCode, FiFileText, FiLayers, FiLayout } from 'react-icons/fi';
 import './Carousel.css';

--- a/src/ts-default/Components/DecayCard/DecayCard.tsx
+++ b/src/ts-default/Components/DecayCard/DecayCard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, ReactNode } from 'react';
+import React, { useEffect, useRef, type ReactNode } from 'react';
 import { gsap } from 'gsap';
 import './DecayCard.css';
 

--- a/src/ts-default/Components/FluidGlass/FluidGlass.tsx
+++ b/src/ts-default/Components/FluidGlass/FluidGlass.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/no-unknown-property */
 import * as THREE from 'three';
-import { useRef, useState, useEffect, memo, ReactNode } from 'react';
-import { Canvas, createPortal, useFrame, useThree, ThreeElements } from '@react-three/fiber';
+import { useRef, useState, useEffect, memo, type ReactNode } from 'react';
+import { Canvas, createPortal, useFrame, useThree, type ThreeElements } from '@react-three/fiber';
 import {
   useFBO,
   useGLTF,

--- a/src/ts-default/Components/InfiniteMenu/InfiniteMenu.tsx
+++ b/src/ts-default/Components/InfiniteMenu/InfiniteMenu.tsx
@@ -1,4 +1,4 @@
-import { FC, useRef, useState, useEffect, MutableRefObject } from 'react';
+import { type FC, useRef, useState, useEffect, type MutableRefObject } from 'react';
 import { mat4, quat, vec2, vec3 } from 'gl-matrix';
 import './InfiniteMenu.css';
 

--- a/src/ts-default/Components/LineSidebar/LineSidebar.tsx
+++ b/src/ts-default/Components/LineSidebar/LineSidebar.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useCallback, useEffect, CSSProperties } from 'react';
+import { useRef, useState, useCallback, useEffect, type CSSProperties } from 'react';
 import './LineSidebar.css';
 
 type Falloff = 'linear' | 'smooth' | 'sharp';

--- a/src/ts-default/Components/ModelViewer/ModelViewer.tsx
+++ b/src/ts-default/Components/ModelViewer/ModelViewer.tsx
@@ -1,4 +1,4 @@
-import { FC, Suspense, useRef, useLayoutEffect, useEffect, useMemo } from 'react';
+import { type FC, Suspense, useRef, useLayoutEffect, useEffect, useMemo } from 'react';
 import { Canvas, useFrame, useLoader, useThree, invalidate } from '@react-three/fiber';
 import { OrbitControls, useGLTF, useFBX, useProgress, Html, Environment, ContactShadows } from '@react-three/drei';
 import { OBJLoader } from 'three/examples/jsm/loaders/OBJLoader';

--- a/src/ts-default/Components/OptionWheel/OptionWheel.tsx
+++ b/src/ts-default/Components/OptionWheel/OptionWheel.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useCallback, useEffect, CSSProperties } from 'react';
+import { useRef, useState, useCallback, useEffect, type CSSProperties } from 'react';
 import './OptionWheel.css';
 
 type Side = 'left' | 'right';

--- a/src/ts-default/Components/PixelCard/PixelCard.tsx
+++ b/src/ts-default/Components/PixelCard/PixelCard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { JSX } from 'react';
+import { type JSX } from 'react';
 import './PixelCard.css';
 
 class Pixel {

--- a/src/ts-default/Components/SpecularButton/SpecularButton.tsx
+++ b/src/ts-default/Components/SpecularButton/SpecularButton.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, CSSProperties, ReactNode, MouseEventHandler } from 'react';
+import { useRef, useEffect, type CSSProperties, type ReactNode, type MouseEventHandler } from 'react';
 import { Renderer, Program, Mesh, Triangle, Color } from 'ogl';
 import './SpecularButton.css';
 

--- a/src/ts-default/Components/Stepper/Stepper.tsx
+++ b/src/ts-default/Components/Stepper/Stepper.tsx
@@ -1,5 +1,5 @@
-import { AnimatePresence, motion, Variants } from 'motion/react';
-import React, { Children, HTMLAttributes, JSX, ReactNode, useLayoutEffect, useRef, useState } from 'react';
+import { AnimatePresence, motion, type Variants } from 'motion/react';
+import React, { Children, type HTMLAttributes, type JSX, type ReactNode, useLayoutEffect, useRef, useState } from 'react';
 
 import './Stepper.css';
 

--- a/src/ts-default/TextAnimations/BlurText/BlurText.tsx
+++ b/src/ts-default/TextAnimations/BlurText/BlurText.tsx
@@ -1,4 +1,4 @@
-import { motion, Transition } from 'motion/react';
+import { motion, type Transition } from 'motion/react';
 import { useEffect, useRef, useState, useMemo } from 'react';
 
 type BlurTextProps = {

--- a/src/ts-default/TextAnimations/CircularText/CircularText.tsx
+++ b/src/ts-default/TextAnimations/CircularText/CircularText.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { motion, useAnimation, useMotionValue, MotionValue, Transition } from 'motion/react';
+import { motion, useAnimation, useMotionValue, MotionValue, type Transition } from 'motion/react';
 
 import './CircularText.css';
 interface CircularTextProps {

--- a/src/ts-default/TextAnimations/CurvedLoop/CurvedLoop.tsx
+++ b/src/ts-default/TextAnimations/CurvedLoop/CurvedLoop.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useState, useMemo, useId, FC, PointerEvent } from 'react';
+import { useRef, useEffect, useState, useMemo, useId, type FC, type PointerEvent } from 'react';
 import './CurvedLoop.css';
 
 interface CurvedLoopProps {

--- a/src/ts-default/TextAnimations/GlitchText/GlitchText.tsx
+++ b/src/ts-default/TextAnimations/GlitchText/GlitchText.tsx
@@ -1,4 +1,4 @@
-import { FC, CSSProperties } from 'react';
+import { type FC, type CSSProperties } from 'react';
 import './GlitchText.css';
 
 interface GlitchTextProps {

--- a/src/ts-default/TextAnimations/GradientText/GradientText.tsx
+++ b/src/ts-default/TextAnimations/GradientText/GradientText.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef, ReactNode } from 'react';
+import { useState, useCallback, useEffect, useRef, type ReactNode } from 'react';
 import { motion, useMotionValue, useAnimationFrame, useTransform } from 'motion/react';
 import './GradientText.css';
 

--- a/src/ts-default/TextAnimations/RotatingText/RotatingText.tsx
+++ b/src/ts-default/TextAnimations/RotatingText/RotatingText.tsx
@@ -4,7 +4,7 @@ import React, { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo
 import {
   motion,
   AnimatePresence,
-  Transition,
+  type Transition,
   type VariantLabels,
   type Target,
   type TargetAndTransition

--- a/src/ts-default/TextAnimations/ScrollFloat/ScrollFloat.tsx
+++ b/src/ts-default/TextAnimations/ScrollFloat/ScrollFloat.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, ReactNode, RefObject } from 'react';
+import React, { useEffect, useMemo, useRef, type ReactNode, type RefObject } from 'react';
 import { gsap } from 'gsap';
 import { ScrollTrigger } from 'gsap/ScrollTrigger';
 

--- a/src/ts-default/TextAnimations/ScrollReveal/ScrollReveal.tsx
+++ b/src/ts-default/TextAnimations/ScrollReveal/ScrollReveal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useMemo, ReactNode, RefObject } from 'react';
+import React, { useEffect, useRef, useMemo, type ReactNode, type RefObject } from 'react';
 import { gsap } from 'gsap';
 import { ScrollTrigger } from 'gsap/ScrollTrigger';
 import './ScrollReveal.css';

--- a/src/ts-default/TextAnimations/TextType/TextType.tsx
+++ b/src/ts-default/TextAnimations/TextType/TextType.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ElementType, useEffect, useRef, useState, createElement, useMemo, useCallback } from 'react';
+import { type ElementType, useEffect, useRef, useState, createElement, useMemo, useCallback } from 'react';
 import { gsap } from 'gsap';
 import './TextType.css';
 

--- a/src/ts-default/TextAnimations/TrueFocus/TrueFocus.tsx
+++ b/src/ts-default/TextAnimations/TrueFocus/TrueFocus.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, RefObject } from 'react';
+import { useEffect, useRef, useState, type RefObject } from 'react';
 import { motion } from 'motion/react';
 import './TrueFocus.css';
 

--- a/src/ts-default/TextAnimations/VariableProximity/VariableProximity.tsx
+++ b/src/ts-default/TextAnimations/VariableProximity/VariableProximity.tsx
@@ -1,4 +1,12 @@
-import { forwardRef, useMemo, useRef, useEffect, MutableRefObject, RefObject, HTMLAttributes } from 'react';
+import {
+  forwardRef,
+  useMemo,
+  useRef,
+  useEffect,
+  type MutableRefObject,
+  type RefObject,
+  type HTMLAttributes
+} from 'react';
 import { motion } from 'motion/react';
 import './VariableProximity.css';
 

--- a/src/ts-tailwind/Animations/Crosshair/Crosshair.tsx
+++ b/src/ts-tailwind/Animations/Crosshair/Crosshair.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, RefObject } from 'react';
+import React, { useEffect, useRef, type RefObject } from 'react';
 import { gsap } from 'gsap';
 
 const lerp = (a: number, b: number, n: number): number => (1 - n) * a + n * b;

--- a/src/ts-tailwind/Animations/ElectricBorder/ElectricBorder.tsx
+++ b/src/ts-tailwind/Animations/ElectricBorder/ElectricBorder.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useCallback, CSSProperties, ReactNode } from 'react';
+import React, { useEffect, useRef, useCallback, type CSSProperties, type ReactNode } from 'react';
 
 function hexToRgba(hex: string, alpha: number = 1): string {
   if (!hex) return `rgba(0,0,0,${alpha})`;

--- a/src/ts-tailwind/Animations/GradualBlur/GradualBlur.tsx
+++ b/src/ts-tailwind/Animations/GradualBlur/GradualBlur.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, useEffect, useRef, useState, useMemo, PropsWithChildren } from 'react';
+import React, { type CSSProperties, useEffect, useRef, useState, useMemo, type PropsWithChildren } from 'react';
 
 type GradualBlurProps = PropsWithChildren<{
   position?: 'top' | 'bottom' | 'left' | 'right';

--- a/src/ts-tailwind/Animations/ImageTrail/ImageTrail.tsx
+++ b/src/ts-tailwind/Animations/ImageTrail/ImageTrail.tsx
@@ -1,5 +1,5 @@
 import { gsap } from 'gsap';
-import { JSX, useEffect, useRef } from 'react';
+import { type JSX, useEffect, useRef } from 'react';
 
 function lerp(a: number, b: number, n: number): number {
   return (1 - n) * a + n * b;

--- a/src/ts-tailwind/Animations/Magnet/Magnet.tsx
+++ b/src/ts-tailwind/Animations/Magnet/Magnet.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, ReactNode, HTMLAttributes } from 'react';
+import React, { useState, useEffect, useRef, type ReactNode, type HTMLAttributes } from 'react';
 
 interface MagnetProps extends HTMLAttributes<HTMLDivElement> {
   children: ReactNode;

--- a/src/ts-tailwind/Animations/MagnetLines/MagnetLines.tsx
+++ b/src/ts-tailwind/Animations/MagnetLines/MagnetLines.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, CSSProperties } from 'react';
+import React, { useRef, useEffect, type CSSProperties } from 'react';
 
 interface MagnetLinesProps {
   rows?: number;

--- a/src/ts-tailwind/Animations/OrbitImages/OrbitImages.tsx
+++ b/src/ts-tailwind/Animations/OrbitImages/OrbitImages.tsx
@@ -1,7 +1,7 @@
 // Component created by Dominik Koch
 // https://x.com/dominikkoch
 
-import { useMemo, useEffect, useLayoutEffect, useRef, useState, ReactNode } from 'react';
+import { useMemo, useEffect, useLayoutEffect, useRef, useState, type ReactNode } from 'react';
 import { motion, useMotionValue, useTransform, animate, MotionValue } from 'motion/react';
 
 type OrbitShape =

--- a/src/ts-tailwind/Animations/PixelTrail/PixelTrail.tsx
+++ b/src/ts-tailwind/Animations/PixelTrail/PixelTrail.tsx
@@ -1,5 +1,5 @@
 import { shaderMaterial, useTrailTexture } from '@react-three/drei';
-import { Canvas, CanvasProps, ThreeEvent, useThree } from '@react-three/fiber';
+import { Canvas, type CanvasProps, type ThreeEvent, useThree } from '@react-three/fiber';
 import React, { useEffect, useMemo } from 'react';
 import * as THREE from 'three';
 

--- a/src/ts-tailwind/Animations/PixelTransition/PixelTransition.tsx
+++ b/src/ts-tailwind/Animations/PixelTransition/PixelTransition.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, useState, CSSProperties } from 'react';
+import React, { useRef, useEffect, useState, type CSSProperties } from 'react';
 import { gsap } from 'gsap';
 
 interface PixelTransitionProps {

--- a/src/ts-tailwind/Animations/ShapeBlur/ShapeBlur.tsx
+++ b/src/ts-tailwind/Animations/ShapeBlur/ShapeBlur.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useRef } from 'react';
+import { type FC, useEffect, useRef } from 'react';
 import * as THREE from 'three';
 
 const vertexShader = /* glsl */ `

--- a/src/ts-tailwind/Animations/StickerPeel/StickerPeel.tsx
+++ b/src/ts-tailwind/Animations/StickerPeel/StickerPeel.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useMemo, CSSProperties } from 'react';
+import { useRef, useEffect, useMemo, type CSSProperties } from 'react';
 import { gsap } from 'gsap';
 import { Draggable } from 'gsap/Draggable';
 

--- a/src/ts-tailwind/Animations/Strands/Strands.tsx
+++ b/src/ts-tailwind/Animations/Strands/Strands.tsx
@@ -1,5 +1,5 @@
 import { Renderer, Program, Mesh, Color, Triangle, RenderTarget } from 'ogl';
-import { useEffect, useRef, CSSProperties } from 'react';
+import { useEffect, useRef, type CSSProperties } from 'react';
 
 const MAX_STRANDS = 12;
 const MAX_COLORS = 8;

--- a/src/ts-tailwind/Backgrounds/Ballpit/Ballpit.tsx
+++ b/src/ts-tailwind/Backgrounds/Ballpit/Ballpit.tsx
@@ -22,7 +22,7 @@ import {
   Vector2,
   Vector3,
   WebGLRenderer,
-  WebGLRendererParameters
+  type WebGLRendererParameters
 } from 'three';
 import { RoomEnvironment } from 'three/examples/jsm/environments/RoomEnvironment.js';
 

--- a/src/ts-tailwind/Backgrounds/Beams/Beams.tsx
+++ b/src/ts-tailwind/Backgrounds/Beams/Beams.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useImperativeHandle, useEffect, useRef, useMemo, FC, ReactNode } from 'react';
+import { forwardRef, useImperativeHandle, useEffect, useRef, useMemo, type FC, type ReactNode } from 'react';
 
 import * as THREE from 'three';
 

--- a/src/ts-tailwind/Backgrounds/Dither/Dither.tsx
+++ b/src/ts-tailwind/Backgrounds/Dither/Dither.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-unknown-property */
 import { useRef, useState, useEffect, forwardRef } from 'react';
-import { Canvas, useFrame, useThree, ThreeEvent } from '@react-three/fiber';
+import { Canvas, useFrame, useThree, type ThreeEvent } from '@react-three/fiber';
 import { EffectComposer, wrapEffect } from '@react-three/postprocessing';
 import { Effect } from 'postprocessing';
 import * as THREE from 'three';

--- a/src/ts-tailwind/Backgrounds/GridMotion/GridMotion.tsx
+++ b/src/ts-tailwind/Backgrounds/GridMotion/GridMotion.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, FC, ReactNode } from 'react';
+import { useEffect, useRef, type FC, type ReactNode } from 'react';
 import { gsap } from 'gsap';
 
 interface GridMotionProps {

--- a/src/ts-tailwind/Backgrounds/Hyperspeed/Hyperspeed.tsx
+++ b/src/ts-tailwind/Backgrounds/Hyperspeed/Hyperspeed.tsx
@@ -1,5 +1,5 @@
 import { BloomEffect, EffectComposer, EffectPass, RenderPass, SMAAEffect, SMAAPreset } from 'postprocessing';
-import { FC, useEffect, useRef } from 'react';
+import { type FC, useEffect, useRef } from 'react';
 import * as THREE from 'three';
 
 interface Distortion {

--- a/src/ts-tailwind/Backgrounds/Silk/Silk.tsx
+++ b/src/ts-tailwind/Backgrounds/Silk/Silk.tsx
@@ -1,8 +1,8 @@
 /* eslint-disable react/no-unknown-property */
 import React, { forwardRef, useMemo, useRef, useLayoutEffect, useEffect } from 'react';
-import { Canvas, useFrame, useThree, RootState } from '@react-three/fiber';
+import { Canvas, useFrame, useThree, type RootState } from '@react-three/fiber';
 import { Color, Mesh, ShaderMaterial } from 'three';
-import { IUniform } from 'three';
+import { type IUniform } from 'three';
 
 type NormalizedRGB = [number, number, number];
 

--- a/src/ts-tailwind/Backgrounds/Waves/Waves.tsx
+++ b/src/ts-tailwind/Backgrounds/Waves/Waves.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, CSSProperties } from 'react';
+import React, { useRef, useEffect, type CSSProperties } from 'react';
 
 class Grad {
   x: number;

--- a/src/ts-tailwind/Components/AnimatedList/AnimatedList.tsx
+++ b/src/ts-tailwind/Components/AnimatedList/AnimatedList.tsx
@@ -1,4 +1,12 @@
-import React, { useRef, useState, useEffect, useCallback, ReactNode, MouseEventHandler, UIEvent } from 'react';
+import React, {
+  useRef,
+  useState,
+  useEffect,
+  useCallback,
+  type ReactNode,
+  type MouseEventHandler,
+  type UIEvent
+} from 'react';
 import { motion, useInView } from 'motion/react';
 
 interface AnimatedItemProps {

--- a/src/ts-tailwind/Components/CardSwap/CardSwap.tsx
+++ b/src/ts-tailwind/Components/CardSwap/CardSwap.tsx
@@ -3,9 +3,9 @@ import React, {
   cloneElement,
   forwardRef,
   isValidElement,
-  ReactElement,
-  ReactNode,
-  RefObject,
+  type ReactElement,
+  type ReactNode,
+  type RefObject,
   useEffect,
   useMemo,
   useRef

--- a/src/ts-tailwind/Components/Carousel/Carousel.tsx
+++ b/src/ts-tailwind/Components/Carousel/Carousel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { motion, PanInfo, useMotionValue, useTransform } from 'motion/react';
-import React, { JSX } from 'react';
+import { motion, type PanInfo, useMotionValue, useTransform } from 'motion/react';
+import React, { type JSX } from 'react';
 
 // replace icons with your own if needed
 import { FiCircle, FiCode, FiFileText, FiLayers, FiLayout } from 'react-icons/fi';

--- a/src/ts-tailwind/Components/DecayCard/DecayCard.tsx
+++ b/src/ts-tailwind/Components/DecayCard/DecayCard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, ReactNode } from 'react';
+import React, { useEffect, useRef, type ReactNode } from 'react';
 import { gsap } from 'gsap';
 
 interface DecayCardProps {

--- a/src/ts-tailwind/Components/FluidGlass/FluidGlass.tsx
+++ b/src/ts-tailwind/Components/FluidGlass/FluidGlass.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/no-unknown-property */
 import * as THREE from 'three';
-import { useRef, useState, useEffect, memo, ReactNode } from 'react';
-import { Canvas, createPortal, useFrame, useThree, ThreeElements } from '@react-three/fiber';
+import { useRef, useState, useEffect, memo, type ReactNode } from 'react';
+import { Canvas, createPortal, useFrame, useThree, type ThreeElements } from '@react-three/fiber';
 import {
   useFBO,
   useGLTF,

--- a/src/ts-tailwind/Components/InfiniteMenu/InfiniteMenu.tsx
+++ b/src/ts-tailwind/Components/InfiniteMenu/InfiniteMenu.tsx
@@ -1,4 +1,4 @@
-import { FC, useRef, useState, useEffect, MutableRefObject } from 'react';
+import { type FC, useRef, useState, useEffect, type MutableRefObject } from 'react';
 import { mat4, quat, vec2, vec3 } from 'gl-matrix';
 
 const discVertShaderSource = `#version 300 es

--- a/src/ts-tailwind/Components/LineSidebar/LineSidebar.tsx
+++ b/src/ts-tailwind/Components/LineSidebar/LineSidebar.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useCallback, useEffect, CSSProperties } from 'react';
+import { useRef, useState, useCallback, useEffect, type CSSProperties } from 'react';
 
 type Falloff = 'linear' | 'smooth' | 'sharp';
 

--- a/src/ts-tailwind/Components/ModelViewer/ModelViewer.tsx
+++ b/src/ts-tailwind/Components/ModelViewer/ModelViewer.tsx
@@ -1,4 +1,4 @@
-import { FC, Suspense, useRef, useLayoutEffect, useEffect, useMemo } from 'react';
+import { type FC, Suspense, useRef, useLayoutEffect, useEffect, useMemo } from 'react';
 import { Canvas, useFrame, useLoader, useThree, invalidate } from '@react-three/fiber';
 import { OrbitControls, useGLTF, useFBX, useProgress, Html, Environment, ContactShadows } from '@react-three/drei';
 import { OBJLoader } from 'three/examples/jsm/loaders/OBJLoader';

--- a/src/ts-tailwind/Components/OptionWheel/OptionWheel.tsx
+++ b/src/ts-tailwind/Components/OptionWheel/OptionWheel.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useCallback, useEffect, CSSProperties } from 'react';
+import { useRef, useState, useCallback, useEffect, type CSSProperties } from 'react';
 
 type Side = 'left' | 'right';
 

--- a/src/ts-tailwind/Components/PixelCard/PixelCard.tsx
+++ b/src/ts-tailwind/Components/PixelCard/PixelCard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { JSX } from 'react';
+import { type JSX } from 'react';
 
 class Pixel {
   width: number;

--- a/src/ts-tailwind/Components/SpecularButton/SpecularButton.tsx
+++ b/src/ts-tailwind/Components/SpecularButton/SpecularButton.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, CSSProperties, ReactNode, MouseEventHandler } from 'react';
+import { useRef, useEffect, type CSSProperties, type ReactNode, type MouseEventHandler } from 'react';
 import { Renderer, Program, Mesh, Triangle, Color } from 'ogl';
 
 type ButtonSize = 'sm' | 'md' | 'lg';

--- a/src/ts-tailwind/Components/Stepper/Stepper.tsx
+++ b/src/ts-tailwind/Components/Stepper/Stepper.tsx
@@ -1,5 +1,5 @@
-import React, { useState, Children, useRef, useLayoutEffect, HTMLAttributes, ReactNode } from 'react';
-import { motion, AnimatePresence, Variants } from 'motion/react';
+import React, { useState, Children, useRef, useLayoutEffect, type HTMLAttributes, type ReactNode } from 'react';
+import { motion, AnimatePresence, type Variants } from 'motion/react';
 
 interface StepperProps extends HTMLAttributes<HTMLDivElement> {
   children: ReactNode;

--- a/src/ts-tailwind/TextAnimations/BlurText/BlurText.tsx
+++ b/src/ts-tailwind/TextAnimations/BlurText/BlurText.tsx
@@ -1,4 +1,4 @@
-import { motion, Transition, Easing } from 'motion/react';
+import { motion, type Transition, type Easing } from 'motion/react';
 import { useEffect, useRef, useState, useMemo } from 'react';
 
 type BlurTextProps = {

--- a/src/ts-tailwind/TextAnimations/CircularText/CircularText.tsx
+++ b/src/ts-tailwind/TextAnimations/CircularText/CircularText.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { motion, useAnimation, useMotionValue, MotionValue, Transition } from 'motion/react';
+import { motion, useAnimation, useMotionValue, MotionValue, type Transition } from 'motion/react';
 interface CircularTextProps {
   text: string;
   spinDuration?: number;

--- a/src/ts-tailwind/TextAnimations/CurvedLoop/CurvedLoop.tsx
+++ b/src/ts-tailwind/TextAnimations/CurvedLoop/CurvedLoop.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useState, useMemo, useId, FC, PointerEvent } from 'react';
+import { useRef, useEffect, useState, useMemo, useId, type FC, type PointerEvent } from 'react';
 
 interface CurvedLoopProps {
   marqueeText?: string;

--- a/src/ts-tailwind/TextAnimations/GlitchText/GlitchText.tsx
+++ b/src/ts-tailwind/TextAnimations/GlitchText/GlitchText.tsx
@@ -1,4 +1,4 @@
-import { FC, CSSProperties } from 'react';
+import { type FC, type CSSProperties } from 'react';
 
 interface GlitchTextProps {
   children: string;

--- a/src/ts-tailwind/TextAnimations/GradientText/GradientText.tsx
+++ b/src/ts-tailwind/TextAnimations/GradientText/GradientText.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef, ReactNode } from 'react';
+import { useState, useCallback, useEffect, useRef, type ReactNode } from 'react';
 import { motion, useMotionValue, useAnimationFrame, useTransform } from 'motion/react';
 
 interface GradientTextProps {

--- a/src/ts-tailwind/TextAnimations/RotatingText/RotatingText.tsx
+++ b/src/ts-tailwind/TextAnimations/RotatingText/RotatingText.tsx
@@ -2,7 +2,7 @@ import React, { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo
 import {
   motion,
   AnimatePresence,
-  Transition,
+  type Transition,
   type VariantLabels,
   type Target,
   type TargetAndTransition

--- a/src/ts-tailwind/TextAnimations/ScrollFloat/ScrollFloat.tsx
+++ b/src/ts-tailwind/TextAnimations/ScrollFloat/ScrollFloat.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, ReactNode, RefObject } from 'react';
+import React, { useEffect, useMemo, useRef, type ReactNode, type RefObject } from 'react';
 import { gsap } from 'gsap';
 import { ScrollTrigger } from 'gsap/ScrollTrigger';
 

--- a/src/ts-tailwind/TextAnimations/ScrollReveal/ScrollReveal.tsx
+++ b/src/ts-tailwind/TextAnimations/ScrollReveal/ScrollReveal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useMemo, ReactNode, RefObject } from 'react';
+import React, { useEffect, useRef, useMemo, type ReactNode, type RefObject } from 'react';
 import { gsap } from 'gsap';
 import { ScrollTrigger } from 'gsap/ScrollTrigger';
 

--- a/src/ts-tailwind/TextAnimations/Shuffle/Shuffle.tsx
+++ b/src/ts-tailwind/TextAnimations/Shuffle/Shuffle.tsx
@@ -3,7 +3,7 @@ import { gsap } from 'gsap';
 import { ScrollTrigger } from 'gsap/ScrollTrigger';
 import { SplitText as GSAPSplitText } from 'gsap/SplitText';
 import { useGSAP } from '@gsap/react';
-import { JSX } from 'react';
+import { type JSX } from 'react';
 
 gsap.registerPlugin(ScrollTrigger, GSAPSplitText);
 

--- a/src/ts-tailwind/TextAnimations/TextType/TextType.tsx
+++ b/src/ts-tailwind/TextAnimations/TextType/TextType.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ElementType, useEffect, useRef, useState, createElement, useMemo, useCallback } from 'react';
+import { type ElementType, useEffect, useRef, useState, createElement, useMemo, useCallback } from 'react';
 import { gsap } from 'gsap';
 
 interface TextTypeProps {

--- a/src/ts-tailwind/TextAnimations/VariableProximity/VariableProximity.tsx
+++ b/src/ts-tailwind/TextAnimations/VariableProximity/VariableProximity.tsx
@@ -1,4 +1,12 @@
-import { forwardRef, useMemo, useRef, useEffect, MutableRefObject, CSSProperties, HTMLAttributes } from 'react';
+import {
+  forwardRef,
+  useMemo,
+  useRef,
+  useEffect,
+  type MutableRefObject,
+  type CSSProperties,
+  type HTMLAttributes
+} from 'react';
 import { motion } from 'motion/react';
 
 function useAnimationFrame(callback: () => void) {


### PR DESCRIPTION
## The problem

React Bits components are meant to be copied into a consumer's project. A stock
`npm create vite@latest -- --template react-ts` project ships
`verbatimModuleSyntax: true`, and under that flag every TS variant that imports
a type through a value import fails to compile.

Reproduction, against `main` as it is today:

```bash
npm create vite@latest repro -- --template react-ts
cd repro && npm i
curl -o src/Magnet.tsx https://raw.githubusercontent.com/DavidHDev/react-bits/main/src/ts-default/Animations/Magnet/Magnet.tsx
npx tsc --noEmit
```

```
src/Magnet.tsx(1,46): error TS1484: 'ReactNode' is a type and must be imported
  using a type-only import when 'verbatimModuleSyntax' is enabled.
src/Magnet.tsx(1,57): error TS1484: 'HTMLAttributes' is a type and must be
  imported using a type-only import when 'verbatimModuleSyntax' is enabled.
```

With this branch, the same check exits 0.

## Why CI is green on `main` even though this is broken

This repo's own `tsconfig.json` sets `isolatedModules` but **not**
`verbatimModuleSyntax`, so `tsc` here never raises TS1484. The breakage only
appears downstream, in the consumer project — which is the only place these
files are ever compiled. That is why there is no failing test to point at.

If you would rather catch this in CI going forward, adding
`"verbatimModuleSyntax": true` to `tsconfig.json` would do it. I left that out
of this PR deliberately since it changes your build config.

## What this changes

83 `.tsx` files, mechanically: type-only specifiers (`type Foo`) for imports
that are types. `+126 / -94`. No runtime change — `verbatimModuleSyntax`
governs emit of import statements only.

Generated `public/r/**` artifacts are **not** included; `npm run build` runs
`registry:build` and regenerates them.

Precedent: magicui merged the identical fix for the same root cause in
magicuidesign/magicui#993.

## Reviewing this

The diff is wide but shallow — one line per file in most cases. The mechanical
check is that every added `type` keyword sits in front of an identifier that is
only ever used in a type position.
