### PR TITLE
fix(Ballpit): bind resize/visibility handlers once so removeEventListener works

### DIFF
--- a/src/content/Backgrounds/Ballpit/Ballpit.jsx
+++ b/src/content/Backgrounds/Ballpit/Ballpit.jsx
@@ -42,6 +42,11 @@ class x {
   onAfterResize = () => {};
   #s = false;
   #n = false;
+  // Bind once: `.bind()` returns a new function on every call, so binding again
+  // in the teardown would hand removeEventListener a function that was never
+  // registered, leaving the listener attached for the lifetime of the page.
+  #boundResize = this.#f.bind(this);
+  #boundVisibilityChange = this.#v.bind(this);
   isDisposed = false;
   #o;
   #r;
@@ -83,7 +88,7 @@ class x {
   }
   #g() {
     if (!(this.#e.size instanceof Object)) {
-      window.addEventListener('resize', this.#f.bind(this));
+      window.addEventListener('resize', this.#boundResize);
       if (this.#e.size === 'parent' && this.canvas.parentNode) {
         this.#r = new ResizeObserver(this.#f.bind(this));
         this.#r.observe(this.canvas.parentNode);
@@ -95,13 +100,13 @@ class x {
       threshold: 0
     });
     this.#o.observe(this.canvas);
-    document.addEventListener('visibilitychange', this.#v.bind(this));
+    document.addEventListener('visibilitychange', this.#boundVisibilityChange);
   }
   #y() {
-    window.removeEventListener('resize', this.#f.bind(this));
+    window.removeEventListener('resize', this.#boundResize);
     this.#r?.disconnect();
     this.#o?.disconnect();
-    document.removeEventListener('visibilitychange', this.#v.bind(this));
+    document.removeEventListener('visibilitychange', this.#boundVisibilityChange);
   }
   #u(e) {
     this.#s = e[0].isIntersecting;

--- a/src/tailwind/Backgrounds/Ballpit/Ballpit.jsx
+++ b/src/tailwind/Backgrounds/Ballpit/Ballpit.jsx
@@ -42,6 +42,11 @@ class x {
   onAfterResize = () => {};
   #s = false;
   #n = false;
+  // Bind once: `.bind()` returns a new function on every call, so binding again
+  // in the teardown would hand removeEventListener a function that was never
+  // registered, leaving the listener attached for the lifetime of the page.
+  #boundResize = this.#f.bind(this);
+  #boundVisibilityChange = this.#v.bind(this);
   isDisposed = false;
   #o;
   #r;
@@ -83,7 +88,7 @@ class x {
   }
   #g() {
     if (!(this.#e.size instanceof Object)) {
-      window.addEventListener('resize', this.#f.bind(this));
+      window.addEventListener('resize', this.#boundResize);
       if (this.#e.size === 'parent' && this.canvas.parentNode) {
         this.#r = new ResizeObserver(this.#f.bind(this));
         this.#r.observe(this.canvas.parentNode);
@@ -95,13 +100,13 @@ class x {
       threshold: 0
     });
     this.#o.observe(this.canvas);
-    document.addEventListener('visibilitychange', this.#v.bind(this));
+    document.addEventListener('visibilitychange', this.#boundVisibilityChange);
   }
   #y() {
-    window.removeEventListener('resize', this.#f.bind(this));
+    window.removeEventListener('resize', this.#boundResize);
     this.#r?.disconnect();
     this.#o?.disconnect();
-    document.removeEventListener('visibilitychange', this.#v.bind(this));
+    document.removeEventListener('visibilitychange', this.#boundVisibilityChange);
   }
   #u(e) {
     this.#s = e[0].isIntersecting;

--- a/src/ts-default/Backgrounds/Ballpit/Ballpit.tsx
+++ b/src/ts-default/Backgrounds/Ballpit/Ballpit.tsx
@@ -55,6 +55,11 @@ class X {
   #animationState = { elapsed: 0, delta: 0 };
   #isAnimating: boolean = false;
   #isVisible: boolean = false;
+  // Bind once: `.bind()` returns a new function on every call, so binding again
+  // in the teardown would hand removeEventListener a function that was never
+  // registered, leaving the listener attached for the lifetime of the page.
+  #boundResize = this.#onResize.bind(this);
+  #boundVisibilityChange = this.#onVisibilityChange.bind(this);
 
   canvas!: HTMLCanvasElement;
   camera!: PerspectiveCamera;
@@ -123,7 +128,7 @@ class X {
 
   #initObservers() {
     if (!(this.#config.size instanceof Object)) {
-      window.addEventListener('resize', this.#onResize.bind(this));
+      window.addEventListener('resize', this.#boundResize);
       if (this.#config.size === 'parent' && this.canvas.parentNode) {
         this.#resizeObserver = new ResizeObserver(this.#onResize.bind(this));
         this.#resizeObserver.observe(this.canvas.parentNode as Element);
@@ -135,7 +140,7 @@ class X {
       threshold: 0
     });
     this.#intersectionObserver.observe(this.canvas);
-    document.addEventListener('visibilitychange', this.#onVisibilityChange.bind(this));
+    document.addEventListener('visibilitychange', this.#boundVisibilityChange);
   }
 
   #onResize() {
@@ -283,10 +288,10 @@ class X {
   }
 
   #onResizeCleanup() {
-    window.removeEventListener('resize', this.#onResize.bind(this));
+    window.removeEventListener('resize', this.#boundResize);
     this.#resizeObserver?.disconnect();
     this.#intersectionObserver?.disconnect();
-    document.removeEventListener('visibilitychange', this.#onVisibilityChange.bind(this));
+    document.removeEventListener('visibilitychange', this.#boundVisibilityChange);
   }
 }
 

--- a/src/ts-tailwind/Backgrounds/Ballpit/Ballpit.tsx
+++ b/src/ts-tailwind/Backgrounds/Ballpit/Ballpit.tsx
@@ -55,6 +55,11 @@ class X {
   #animationState = { elapsed: 0, delta: 0 };
   #isAnimating: boolean = false;
   #isVisible: boolean = false;
+  // Bind once: `.bind()` returns a new function on every call, so binding again
+  // in the teardown would hand removeEventListener a function that was never
+  // registered, leaving the listener attached for the lifetime of the page.
+  #boundResize = this.#onResize.bind(this);
+  #boundVisibilityChange = this.#onVisibilityChange.bind(this);
 
   canvas!: HTMLCanvasElement;
   camera!: PerspectiveCamera;
@@ -123,7 +128,7 @@ class X {
 
   #initObservers() {
     if (!(this.#config.size instanceof Object)) {
-      window.addEventListener('resize', this.#onResize.bind(this));
+      window.addEventListener('resize', this.#boundResize);
       if (this.#config.size === 'parent' && this.canvas.parentNode) {
         this.#resizeObserver = new ResizeObserver(this.#onResize.bind(this));
         this.#resizeObserver.observe(this.canvas.parentNode as Element);
@@ -135,7 +140,7 @@ class X {
       threshold: 0
     });
     this.#intersectionObserver.observe(this.canvas);
-    document.addEventListener('visibilitychange', this.#onVisibilityChange.bind(this));
+    document.addEventListener('visibilitychange', this.#boundVisibilityChange);
   }
 
   #onResize() {
@@ -283,10 +288,10 @@ class X {
   }
 
   #onResizeCleanup() {
-    window.removeEventListener('resize', this.#onResize.bind(this));
+    window.removeEventListener('resize', this.#boundResize);
     this.#resizeObserver?.disconnect();
     this.#intersectionObserver?.disconnect();
-    document.removeEventListener('visibilitychange', this.#onVisibilityChange.bind(this));
+    document.removeEventListener('visibilitychange', this.#boundVisibilityChange);
   }
 }
 


### PR DESCRIPTION
## The problem

`Ballpit` registers two listeners in `#initObservers` and removes them in the teardown — but binds a *fresh* function each time:

```js
// setup
window.addEventListener('resize', this.#onResize.bind(this));
document.addEventListener('visibilitychange', this.#onVisibilityChange.bind(this));

// teardown
window.removeEventListener('resize', this.#onResize.bind(this));
document.removeEventListener('visibilitychange', this.#onVisibilityChange.bind(this));
```

`.bind()` returns a new function object on every call, so `removeEventListener` is handed something that was never registered and removes nothing. Both listeners stay attached for the lifetime of the page, and each one keeps `this` reachable — the Three.js scene, renderer and canvas with it.

Anything that mounts `Ballpit` more than once hits this: route changes in an SPA, a page that toggles backgrounds, or React StrictMode's double-mount in development.

## Measurement

Stock Vite React-TS app, `Ballpit` mounted then unmounted/remounted four times. Instrumented `addEventListener` / `removeEventListener` to mirror the browser's own bookkeeping — a listener is keyed by `(type, function)`, and a `remove` with a different function object is a no-op, exactly as it is here:

| listener | after 1 mount | after 5 mounts (`main`) | after 5 mounts (this PR) |
|---|---|---|---|
| `window: resize` | 1 | **5** | 1 |
| `document: visibilitychange` | 1 | **5** | 1 |
| `document: selectionchange` (React's own — control) | 1 | 1 | 1 |

The control row is the point: an unrelated listener registered by React stays at 1 across the same cycles, so the growth is `Ballpit`'s and not an artefact of the harness.

## The change

Binds each handler once as a class field and uses that reference for both add and remove:

```js
#boundResize = this.#onResize.bind(this);
#boundVisibilityChange = this.#onVisibilityChange.bind(this);
```

Private methods are installed on the instance before field initialisers run, so this is safe in the field position and needs no constructor changes.

Left alone deliberately: `new ResizeObserver(this.#onResize.bind(this))` also binds inline, but observers are torn down with `.disconnect()`, which doesn't need the original reference — so there is no leak there and no reason to touch it.

## Scope

All four variants, per the contributing guide — `content`, `tailwind`, `ts-default`, `ts-tailwind`. Only the two listener pairs and the new fields changed.

## Verification

- The measurement above, before and after.
- `npx tsc --noEmit`: no new errors in either TS variant.
- `npx vite build`: passes.
- `prettier --check` clean on all four files.

## Note for reproducing

On current `main` the TS variants of `Ballpit` can't be loaded at all in a stock Vite app — `WebGLRendererParameters` is imported as a value from `three`, which fails at both bundle and runtime (see #1018). To measure this leak I applied that one-line `type` modifier locally so the component would load. This PR is independent of #1018 and touches different lines; they merge in either order.
