### PR TITLE
fix(GlassSurface): drop the duplicated resize effect

### DIFF
--- a/src/content/Components/GlassSurface/GlassSurface.jsx
+++ b/src/content/Components/GlassSurface/GlassSurface.jsx
@@ -118,20 +118,6 @@ const GlassSurface = ({
   }, []);
 
   useEffect(() => {
-    if (!containerRef.current) return;
-
-    const resizeObserver = new ResizeObserver(() => {
-      setTimeout(updateDisplacementMap, 0);
-    });
-
-    resizeObserver.observe(containerRef.current);
-
-    return () => {
-      resizeObserver.disconnect();
-    };
-  }, []);
-
-  useEffect(() => {
     setTimeout(updateDisplacementMap, 0);
   }, [width, height]);
 

--- a/src/tailwind/Components/GlassSurface/GlassSurface.jsx
+++ b/src/tailwind/Components/GlassSurface/GlassSurface.jsx
@@ -136,20 +136,6 @@ const GlassSurface = ({
   }, []);
 
   useEffect(() => {
-    if (!containerRef.current) return;
-
-    const resizeObserver = new ResizeObserver(() => {
-      setTimeout(updateDisplacementMap, 0);
-    });
-
-    resizeObserver.observe(containerRef.current);
-
-    return () => {
-      resizeObserver.disconnect();
-    };
-  }, []);
-
-  useEffect(() => {
     setTimeout(updateDisplacementMap, 0);
   }, [width, height]);
 

--- a/src/ts-default/Components/GlassSurface/GlassSurface.tsx
+++ b/src/ts-default/Components/GlassSurface/GlassSurface.tsx
@@ -158,20 +158,6 @@ const GlassSurface: React.FC<GlassSurfaceProps> = ({
   }, []);
 
   useEffect(() => {
-    if (!containerRef.current) return;
-
-    const resizeObserver = new ResizeObserver(() => {
-      setTimeout(updateDisplacementMap, 0);
-    });
-
-    resizeObserver.observe(containerRef.current);
-
-    return () => {
-      resizeObserver.disconnect();
-    };
-  }, []);
-
-  useEffect(() => {
     setTimeout(updateDisplacementMap, 0);
   }, [width, height]);
 

--- a/src/ts-tailwind/Components/GlassSurface/GlassSurface.tsx
+++ b/src/ts-tailwind/Components/GlassSurface/GlassSurface.tsx
@@ -180,20 +180,6 @@ const GlassSurface: React.FC<GlassSurfaceProps> = ({
   }, []);
 
   useEffect(() => {
-    if (!containerRef.current) return;
-
-    const resizeObserver = new ResizeObserver(() => {
-      setTimeout(updateDisplacementMap, 0);
-    });
-
-    resizeObserver.observe(containerRef.current);
-
-    return () => {
-      resizeObserver.disconnect();
-    };
-  }, []);
-
-  useEffect(() => {
     setTimeout(updateDisplacementMap, 0);
   }, [width, height]);
 


### PR DESCRIPTION
## The problem

`GlassSurface` registers the same effect twice. Not similar — byte-identical:

```jsx
useEffect(() => {
  if (!containerRef.current) return;
  const resizeObserver = new ResizeObserver(() => {
    setTimeout(updateDisplacementMap, 0);
  });
  resizeObserver.observe(containerRef.current);
  return () => { resizeObserver.disconnect(); };
}, []);

useEffect(() => {                       // <- the same block again, verbatim
  if (!containerRef.current) return;
  const resizeObserver = new ResizeObserver(() => {
    setTimeout(updateDisplacementMap, 0);
  });
  resizeObserver.observe(containerRef.current);
  return () => { resizeObserver.disconnect(); };
}, []);
```

So every instance runs **two** `ResizeObserver`s on the same element, and each resize regenerates the SVG displacement map twice — that's a `feImage` data-URI rebuild plus `feDisplacementMap` attribute writes, done twice for nothing.

## Measurement

One `<GlassSurface>` in a stock Vite React app, with `ResizeObserver` wrapped to count constructions:

| | ResizeObservers constructed |
|---|---|
| current `main` | **2** |
| this PR | 1 |

Still renders identically after the change — same three `feDisplacementMap` nodes, no console errors, and resizes still update the filter (verified by resizing twice via a width prop).

## Scope

All four variants carry the same duplication, so all four are fixed: `content`, `tailwind`, `ts-default`, `ts-tailwind`. The diff is deletion only — 56 lines removed, nothing added.

## Verification

- `npx tsc --noEmit`: no new errors (zero mentioning GlassSurface).
- `npx prettier --check` clean on all four files.
- `npx vite build` passes.
- Browser check above, before and after.

Found while scanning for effects that create a resource without releasing it; this one turned up because the duplicate made the same file report the same pattern twice.
