### PR TITLE
fix(Lightning, RippleGrid): cancel the render loop on cleanup

### DIFF
--- a/src/content/Backgrounds/Lightning/Lightning.jsx
+++ b/src/content/Backgrounds/Lightning/Lightning.jsx
@@ -154,6 +154,7 @@ const Lightning = ({ hue = 230, xOffset = 0, speed = 1, intensity = 1, size = 1 
     const uIntensityLocation = gl.getUniformLocation(program, 'uIntensity');
     const uSizeLocation = gl.getUniformLocation(program, 'uSize');
 
+    let animationFrameId;
     const startTime = performance.now();
     const render = () => {
       resizeCanvas();
@@ -167,11 +168,12 @@ const Lightning = ({ hue = 230, xOffset = 0, speed = 1, intensity = 1, size = 1 
       gl.uniform1f(uIntensityLocation, intensity);
       gl.uniform1f(uSizeLocation, size);
       gl.drawArrays(gl.TRIANGLES, 0, 6);
-      requestAnimationFrame(render);
+      animationFrameId = requestAnimationFrame(render);
     };
-    requestAnimationFrame(render);
+    animationFrameId = requestAnimationFrame(render);
 
     return () => {
+      cancelAnimationFrame(animationFrameId);
       window.removeEventListener('resize', resizeCanvas);
     };
   }, [hue, xOffset, speed, intensity, size]);

--- a/src/content/Backgrounds/RippleGrid/RippleGrid.jsx
+++ b/src/content/Backgrounds/RippleGrid/RippleGrid.jsx
@@ -201,6 +201,7 @@ void main() {
     }
     resize();
 
+    let animationFrameId;
     const render = t => {
       uniforms.iTime.value = t * 0.001;
 
@@ -215,13 +216,14 @@ void main() {
       uniforms.mousePosition.value = [mousePositionRef.current.x, mousePositionRef.current.y];
 
       renderer.render({ scene: mesh });
-      requestAnimationFrame(render);
+      animationFrameId = requestAnimationFrame(render);
     };
 
-    requestAnimationFrame(render);
+    animationFrameId = requestAnimationFrame(render);
 
     const container = containerRef.current;
     return () => {
+      cancelAnimationFrame(animationFrameId);
       window.removeEventListener('resize', resize);
       if (mouseInteraction && container) {
         container.removeEventListener('mousemove', handleMouseMove);

--- a/src/tailwind/Backgrounds/Lightning/Lightning.jsx
+++ b/src/tailwind/Backgrounds/Lightning/Lightning.jsx
@@ -153,6 +153,7 @@ const Lightning = ({ hue = 230, xOffset = 0, speed = 1, intensity = 1, size = 1 
     const uIntensityLocation = gl.getUniformLocation(program, 'uIntensity');
     const uSizeLocation = gl.getUniformLocation(program, 'uSize');
 
+    let animationFrameId;
     const startTime = performance.now();
     const render = () => {
       resizeCanvas();
@@ -166,11 +167,12 @@ const Lightning = ({ hue = 230, xOffset = 0, speed = 1, intensity = 1, size = 1 
       gl.uniform1f(uIntensityLocation, intensity);
       gl.uniform1f(uSizeLocation, size);
       gl.drawArrays(gl.TRIANGLES, 0, 6);
-      requestAnimationFrame(render);
+      animationFrameId = requestAnimationFrame(render);
     };
-    requestAnimationFrame(render);
+    animationFrameId = requestAnimationFrame(render);
 
     return () => {
+      cancelAnimationFrame(animationFrameId);
       window.removeEventListener('resize', resizeCanvas);
     };
   }, [hue, xOffset, speed, intensity, size]);

--- a/src/tailwind/Backgrounds/RippleGrid/RippleGrid.jsx
+++ b/src/tailwind/Backgrounds/RippleGrid/RippleGrid.jsx
@@ -200,6 +200,7 @@ void main() {
     }
     resize();
 
+    let animationFrameId;
     const render = t => {
       uniforms.iTime.value = t * 0.001;
 
@@ -214,13 +215,14 @@ void main() {
       uniforms.mousePosition.value = [mousePositionRef.current.x, mousePositionRef.current.y];
 
       renderer.render({ scene: mesh });
-      requestAnimationFrame(render);
+      animationFrameId = requestAnimationFrame(render);
     };
 
-    requestAnimationFrame(render);
+    animationFrameId = requestAnimationFrame(render);
 
     const container = containerRef.current;
     return () => {
+      cancelAnimationFrame(animationFrameId);
       window.removeEventListener('resize', resize);
       if (mouseInteraction && container) {
         container.removeEventListener('mousemove', handleMouseMove);

--- a/src/ts-default/Backgrounds/Lightning/Lightning.tsx
+++ b/src/ts-default/Backgrounds/Lightning/Lightning.tsx
@@ -162,6 +162,7 @@ const Lightning: React.FC<LightningProps> = ({ hue = 230, xOffset = 0, speed = 1
     const uIntensityLocation = gl.getUniformLocation(program, 'uIntensity');
     const uSizeLocation = gl.getUniformLocation(program, 'uSize');
 
+    let animationFrameId: number;
     const startTime = performance.now();
     const render = () => {
       resizeCanvas();
@@ -175,11 +176,12 @@ const Lightning: React.FC<LightningProps> = ({ hue = 230, xOffset = 0, speed = 1
       gl.uniform1f(uIntensityLocation, intensity);
       gl.uniform1f(uSizeLocation, size);
       gl.drawArrays(gl.TRIANGLES, 0, 6);
-      requestAnimationFrame(render);
+      animationFrameId = requestAnimationFrame(render);
     };
-    requestAnimationFrame(render);
+    animationFrameId = requestAnimationFrame(render);
 
     return () => {
+      cancelAnimationFrame(animationFrameId);
       window.removeEventListener('resize', resizeCanvas);
     };
   }, [hue, xOffset, speed, intensity, size]);

--- a/src/ts-default/Backgrounds/RippleGrid/RippleGrid.tsx
+++ b/src/ts-default/Backgrounds/RippleGrid/RippleGrid.tsx
@@ -216,6 +216,7 @@ void main() {
     }
     resize();
 
+    let animationFrameId: number;
     const render = (t: number) => {
       uniforms.iTime.value = t * 0.001;
 
@@ -230,12 +231,13 @@ void main() {
       uniforms.mousePosition.value = [mousePositionRef.current.x, mousePositionRef.current.y];
 
       renderer.render({ scene: mesh });
-      requestAnimationFrame(render);
+      animationFrameId = requestAnimationFrame(render);
     };
 
-    requestAnimationFrame(render);
+    animationFrameId = requestAnimationFrame(render);
 
     return () => {
+      cancelAnimationFrame(animationFrameId);
       window.removeEventListener('resize', resize);
       if (mouseInteraction && containerRef.current) {
         containerRef.current.removeEventListener('mousemove', handleMouseMove);

--- a/src/ts-tailwind/Backgrounds/Lightning/Lightning.tsx
+++ b/src/ts-tailwind/Backgrounds/Lightning/Lightning.tsx
@@ -161,6 +161,7 @@ const Lightning: React.FC<LightningProps> = ({ hue = 230, xOffset = 0, speed = 1
     const uIntensityLocation = gl.getUniformLocation(program, 'uIntensity');
     const uSizeLocation = gl.getUniformLocation(program, 'uSize');
 
+    let animationFrameId: number;
     const startTime = performance.now();
     const render = () => {
       resizeCanvas();
@@ -174,11 +175,12 @@ const Lightning: React.FC<LightningProps> = ({ hue = 230, xOffset = 0, speed = 1
       gl.uniform1f(uIntensityLocation, intensity);
       gl.uniform1f(uSizeLocation, size);
       gl.drawArrays(gl.TRIANGLES, 0, 6);
-      requestAnimationFrame(render);
+      animationFrameId = requestAnimationFrame(render);
     };
-    requestAnimationFrame(render);
+    animationFrameId = requestAnimationFrame(render);
 
     return () => {
+      cancelAnimationFrame(animationFrameId);
       window.removeEventListener('resize', resizeCanvas);
     };
   }, [hue, xOffset, speed, intensity, size]);

--- a/src/ts-tailwind/Backgrounds/RippleGrid/RippleGrid.tsx
+++ b/src/ts-tailwind/Backgrounds/RippleGrid/RippleGrid.tsx
@@ -215,6 +215,7 @@ void main() {
     }
     resize();
 
+    let animationFrameId: number;
     const render = (t: number) => {
       uniforms.iTime.value = t * 0.001;
 
@@ -229,12 +230,13 @@ void main() {
       uniforms.mousePosition.value = [mousePositionRef.current.x, mousePositionRef.current.y];
 
       renderer.render({ scene: mesh });
-      requestAnimationFrame(render);
+      animationFrameId = requestAnimationFrame(render);
     };
 
-    requestAnimationFrame(render);
+    animationFrameId = requestAnimationFrame(render);
 
     return () => {
+      cancelAnimationFrame(animationFrameId);
       window.removeEventListener('resize', resize);
       if (mouseInteraction && containerRef.current) {
         containerRef.current.removeEventListener('mousemove', handleMouseMove);


### PR DESCRIPTION
## The problem

`Lightning` and `RippleGrid` each run a self-scheduling `requestAnimationFrame` loop and never cancel it:

```jsx
const render = () => {
  ...
  gl.drawArrays(gl.TRIANGLES, 0, 6);
  requestAnimationFrame(render);      // schedules itself forever
};
requestAnimationFrame(render);

return () => {
  window.removeEventListener('resize', resizeCanvas);   // the loop is not touched
};
```

So the loop outlives the component. `RippleGrid` makes it starker — its cleanup drops the WebGL context and removes the canvas, and the loop then keeps calling `renderer.render(...)` on a context that has been deliberately lost.

`Lightning` has a second problem on top. Its effect depends on `[hue, xOffset, speed, intensity, size]`, so **every prop change re-runs the effect and starts another loop** without stopping the previous one.

## Measurement

`Lightning` in a stock Vite React app, with `requestAnimationFrame` wrapped to count callbacks per second:

| | current `main` | this PR |
|---|---|---|
| 1 mount, no prop changes | ~60/s | ~60/s |
| after changing `hue` 4 times | **~300/s** (5 loops) | ~60/s |
| **after unmounting** | **~305/s** (all 5 still running) | **~0/s** |

The middle row is the prop-change pile-up; the last row is the leak. On `main` the component is gone from the tree and five render loops are still driving WebGL every frame.

`RippleGrid` has the identical loop shape and cleanup omission — I verified that by reading all four variants, but I could not get it to initialise inside my minimal probe harness, so I am **not** claiming a measured number for it.

## The change

Capture the frame id and cancel it in the cleanup:

```jsx
let animationFrameId;
const render = () => {
  ...
  animationFrameId = requestAnimationFrame(render);
};
animationFrameId = requestAnimationFrame(render);

return () => {
  cancelAnimationFrame(animationFrameId);
  window.removeEventListener('resize', resizeCanvas);
};
```

Nothing else changes. On `Lightning` this also means a prop change now cancels the old loop before the effect re-runs, which is what the existing cleanup was always supposed to do.

## Scope

Both components, all four variants — 8 files, +32/-16.

## Verification

- The measurement above, before and after.
- `npx tsc --noEmit`: no errors mentioning either component.
- `npx prettier --check` clean on all eight files.
- `npx vite build` passes.

Found by scanning effects that create a resource without releasing it in the same effect. Three more components (`SplashCursor`, `FallingText`, `Crosshair`) show the same shape; I left them out of this PR so the diff stays to the two I could reason about fully, and can follow up if you want them.
