### PR TITLE
fix(performance): dedupe React dependencies and cache lazy loaded category components

### DIFF
--- a/src/pages/CategoryPage.jsx
+++ b/src/pages/CategoryPage.jsx
@@ -11,14 +11,24 @@ import { SkeletonLoader, GetStartedLoader } from '../components/common/SkeletonL
 import IndexPage from './IndexPage';
 
 const CATEGORY_KEYS = {
-  'components': 'Components',
-  'animations': 'Animations',
-  'backgrounds': 'Backgrounds',
+  components: 'Components',
+  animations: 'Animations',
+  backgrounds: 'Backgrounds',
   'text-animations': 'TextAnimations'
 };
 
 const FALLBACK_DESCRIPTION =
   'High quality, animated, interactive & fully customizable React components for building stunning, memorable user interfaces.';
+
+const lazyComponentCache = new Map();
+
+const getLazyComponent = (subcategory, componentFactory) => {
+  if (!subcategory || !componentFactory) return null;
+  if (!lazyComponentCache.has(subcategory)) {
+    lazyComponentCache.set(subcategory, lazy(componentFactory));
+  }
+  return lazyComponentCache.get(subcategory);
+};
 
 const CategoryPage = () => {
   const { category, subcategory } = useParams();
@@ -32,7 +42,7 @@ const CategoryPage = () => {
 
   const componentFactory = subcategory && componentMap[subcategory];
   const SubcategoryComponent =
-    getPreloadedComponent(subcategory)?.default || (componentFactory ? lazy(componentFactory) : null);
+    getPreloadedComponent(subcategory)?.default || getLazyComponent(subcategory, componentFactory);
   const Loader = isGetStartedRoute ? GetStartedLoader : SkeletonLoader;
 
   useEffect(() => {

--- a/vite.config.js
+++ b/vite.config.js
@@ -14,6 +14,7 @@ export default defineConfig({
     hmr: true
   },
   resolve: {
+    dedupe: ['react', 'react-dom'],
     alias: {
       '@': '/src',
       '@utils': path.resolve(__dirname, 'src/utils'),


### PR DESCRIPTION
## The Bug
When Vite resolves multiple or duplicate instances of `react` and `react-dom` during module resolution or dynamic imports, React throws an `Uncaught Error: Invalid hook call. Hooks can only be called inside of the body of a function component.`
Fixes #1029 
## PR Summary
This PR addresses duplicate React dependency issues and fixes unwanted component remounting during route renders on `CategoryPage`.
## Changes Included
- **Vite Configuration (`vite.config.js`)**:
  - Added `dedupe: ['react', 'react-dom']` under `resolve` to ensure single instance resolution of React across all imports/dependencies.
- **Category Page (`src/pages/CategoryPage.jsx`)**:
  - Introduced module-level `lazyComponentCache` (`Map`) to cache `React.lazy()` component factories.
  - Replaced inline `lazy()` instantiation during render with cached lookup to maintain stable component references and avoid unnecessary unmounting/remounting on re-renders.
## Verification
- Tested navigating across category and subcategory routes to confirm component state and animations remain intact during re-renders.
- Verified local development build with `npm run dev` to ensure no "Invalid hook call" warnings or duplicate React runtime errors occur.