### PR TITLE
fix: stack showcase header vertically on mobile to prevent overflow

### DIFF
--- a/src/css/showcase.css
+++ b/src/css/showcase.css
@@ -155,10 +155,21 @@
 
 @media (max-width: 640px) {
   .showcase-page {
+    /* box-sizing: border-box; */
     padding: 100px 1em 3em;
   }
 
   .showcase-grid {
     grid-template-columns: 1fr;
+  }
+
+  .showcase-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 16px;
+  }
+
+  .showcase-submit-btn {
+    margin-top: 0;
   }
 }

--- a/src/css/showcase.css
+++ b/src/css/showcase.css
@@ -155,7 +155,6 @@
 
 @media (max-width: 640px) {
   .showcase-page {
-    /* box-sizing: border-box; */
     padding: 100px 1em 3em;
   }
 


### PR DESCRIPTION
Fixes 
horizontal overflow on the `/showcase` page at mobile widths, caused 
by `.showcase-header` forcing the title block and submit button into a 
single row that doesn't fit narrow screens.

Closes #1030 

Change
Added a mobile media query (max-width: 640px) that switches .showcase-header from flex-direction: row to column

before
<img width="1920" height="934" alt="Screenshot from 2026-08-08 02-11-05" src="https://github.com/user-attachments/assets/f2750757-458c-49b5-a760-a2fa7357c732" />

after 
<img width="1920" height="934" alt="image" src="https://github.com/user-attachments/assets/bb1eddc9-a9f1-45de-8945-31ec7a5b19fb" />

