### PR TITLE
fix: add neonwaves (six) preset to hyperspeed demo

### DIFF
--- a/src/demo/Backgrounds/HyperspeedDemo.jsx
+++ b/src/demo/Backgrounds/HyperspeedDemo.jsx
@@ -46,7 +46,8 @@ const HyperspeedDemo = () => {
     { value: 'two', label: 'Akira' },
     { value: 'three', label: 'Golden' },
     { value: 'four', label: 'Split' },
-    { value: 'five', label: 'Highway' }
+    { value: 'five', label: 'Highway' },
+    { value: 'six', label: 'Neon Waves' }
   ];
 
   return (


### PR DESCRIPTION
Fixes #1036

## Summary of Changes

Updated `HyperspeedDemo.jsx` by adding the missing preset option `{ value: 'six', label: 'Neon Waves' }` to the options array so that all 6 available Hyperspeed animation presets (Cyberpunk, Akira, Golden, Split, Highway, and Neon Waves) match between Background Studio and the Hyperspeed demo PreviewSelect dropdown.