### PR TITLE
Fix SpecularButton dependencyList by removing extra npm i

### DIFF
--- a/src/constants/code/Components/specularButtonCode.js
+++ b/src/constants/code/Components/specularButtonCode.js
@@ -5,7 +5,7 @@ import tsCode from '@ts-default/Components/SpecularButton/SpecularButton.tsx?raw
 import tsTailwind from '@ts-tailwind/Components/SpecularButton/SpecularButton.tsx?raw';
 
 export const specularButton = {
-  dependencies: `npm i ogl`,
+  dependencies: `ogl`,
   usage: `import SpecularButton from './SpecularButton';
 
 <SpecularButton


### PR DESCRIPTION
## Summary
Fixes the installation command string for SpecularButton which caused redundant `npm i` prefixes when switching package managers.

## Changes
- Updated `dependencyList` in `specularButtonCode.js` from `['npm i ogl']` to `['ogl']`.

Related to #1057 