### PR TITLE
fix(TextLoop): prevent separator duplication causing overlap (#1062)

### DIFF
--- a/src/constants/code/TextAnimations/textLoopCode.js
+++ b/src/constants/code/TextAnimations/textLoopCode.js
@@ -9,7 +9,7 @@ export const textLoop = {
   usage: `import TextLoop from './TextLoop';
 
 <TextLoop
-  text="React ✦ Bits"
+  text="React Bits"
   shape="wave"
   speed={90}
   direction="forward"

--- a/src/content/TextAnimations/TextLoop/TextLoop.jsx
+++ b/src/content/TextAnimations/TextLoop/TextLoop.jsx
@@ -45,7 +45,7 @@ const buildPath = (shape, curviness, ribbonWidth) => {
 };
 
 const TextLoop = ({
-  text = 'React ✦ Bits',
+  text = 'React Bits',
   shape = 'wave',
   path,
   speed = 90,
@@ -78,8 +78,22 @@ const TextLoop = ({
   const d = useMemo(() => path || buildPath(shape, curviness, ribbonWidth), [path, shape, curviness, ribbonWidth]);
 
   const unit = useMemo(() => {
-    const base = uppercase ? String(text).toUpperCase() : String(text);
-    const gap = separator ? `\u00A0${separator}\u00A0` : '\u00A0\u00A0\u00A0';
+    let base = String(text ?? '');
+    let sep = separator ?? '';
+    if (uppercase) {
+      base = base.toUpperCase();
+      sep = sep.toUpperCase();
+    }
+    if (sep) {
+      // Strip any separator glyphs already present in the text so each
+      // repetition is joined by exactly one separator. A duplicated glyph
+      // breaks the textLength/lengthAdjust fit on the SVG path in stricter
+      // browsers (e.g. Firefox) and a separator can land on top of a letter.
+      base = base.split(sep).join('').replace(/[\s\u00A0]+/g, ' ').trim();
+    } else {
+      base = base.replace(/[\s\u00A0]+/g, ' ').trim();
+    }
+    const gap = sep ? `\u00A0${sep}\u00A0` : '\u00A0\u00A0\u00A0';
     return `${base}${gap}`;
   }, [text, separator, uppercase]);
 

--- a/src/demo/TextAnimations/TextLoopDemo.jsx
+++ b/src/demo/TextAnimations/TextLoopDemo.jsx
@@ -19,7 +19,7 @@ import TextLoop from '../../content/TextAnimations/TextLoop/TextLoop';
 import { textLoop } from '../../constants/code/TextAnimations/textLoopCode';
 
 const DEFAULT_PROPS = {
-  text: 'React ✦ Bits',
+  text: 'React Bits',
   shape: 'wave',
   speed: 90,
   direction: 'forward',
@@ -72,7 +72,7 @@ const TextLoopDemo = () => {
 
   const propData = useMemo(
     () => [
-      { name: 'text', type: 'string', default: '"React ✦ Bits"', description: 'The phrase repeated along the curve.' },
+      { name: 'text', type: 'string', default: '"React Bits"', description: 'The phrase repeated along the curve.' },
       {
         name: 'shape',
         type: '"wave" | "circle" | "infinity" | "arch" | "line"',

--- a/src/tailwind/TextAnimations/TextLoop/TextLoop.jsx
+++ b/src/tailwind/TextAnimations/TextLoop/TextLoop.jsx
@@ -43,7 +43,7 @@ const buildPath = (shape, curviness, ribbonWidth) => {
 };
 
 const TextLoop = ({
-  text = 'React ✦ Bits',
+  text = 'React Bits',
   shape = 'wave',
   path,
   speed = 90,
@@ -76,8 +76,22 @@ const TextLoop = ({
   const d = useMemo(() => path || buildPath(shape, curviness, ribbonWidth), [path, shape, curviness, ribbonWidth]);
 
   const unit = useMemo(() => {
-    const base = uppercase ? String(text).toUpperCase() : String(text);
-    const gap = separator ? `\u00A0${separator}\u00A0` : '\u00A0\u00A0\u00A0';
+    let base = String(text ?? '');
+    let sep = separator ?? '';
+    if (uppercase) {
+      base = base.toUpperCase();
+      sep = sep.toUpperCase();
+    }
+    if (sep) {
+      // Strip any separator glyphs already present in the text so each
+      // repetition is joined by exactly one separator. A duplicated glyph
+      // breaks the textLength/lengthAdjust fit on the SVG path in stricter
+      // browsers (e.g. Firefox) and a separator can land on top of a letter.
+      base = base.split(sep).join('').replace(/[\s\u00A0]+/g, ' ').trim();
+    } else {
+      base = base.replace(/[\s\u00A0]+/g, ' ').trim();
+    }
+    const gap = sep ? `\u00A0${sep}\u00A0` : '\u00A0\u00A0\u00A0';
     return `${base}${gap}`;
   }, [text, separator, uppercase]);
 

--- a/src/ts-default/TextAnimations/TextLoop/TextLoop.tsx
+++ b/src/ts-default/TextAnimations/TextLoop/TextLoop.tsx
@@ -74,7 +74,7 @@ const buildPath = (shape: TextLoopShape, curviness: number, ribbonWidth: number)
 };
 
 const TextLoop = ({
-  text = 'React ✦ Bits',
+  text = 'React Bits',
   shape = 'wave',
   path,
   speed = 90,
@@ -107,8 +107,22 @@ const TextLoop = ({
   const d = useMemo(() => path || buildPath(shape, curviness, ribbonWidth), [path, shape, curviness, ribbonWidth]);
 
   const unit = useMemo(() => {
-    const base = uppercase ? String(text).toUpperCase() : String(text);
-    const gap = separator ? `\u00A0${separator}\u00A0` : '\u00A0\u00A0\u00A0';
+    let base = String(text ?? '');
+    let sep = separator ?? '';
+    if (uppercase) {
+      base = base.toUpperCase();
+      sep = sep.toUpperCase();
+    }
+    if (sep) {
+      // Strip any separator glyphs already present in the text so each
+      // repetition is joined by exactly one separator. A duplicated glyph
+      // breaks the textLength/lengthAdjust fit on the SVG path in stricter
+      // browsers (e.g. Firefox) and a separator can land on top of a letter.
+      base = base.split(sep).join('').replace(/[\s\u00A0]+/g, ' ').trim();
+    } else {
+      base = base.replace(/[\s\u00A0]+/g, ' ').trim();
+    }
+    const gap = sep ? `\u00A0${sep}\u00A0` : '\u00A0\u00A0\u00A0';
     return `${base}${gap}`;
   }, [text, separator, uppercase]);
 

--- a/src/ts-tailwind/TextAnimations/TextLoop/TextLoop.tsx
+++ b/src/ts-tailwind/TextAnimations/TextLoop/TextLoop.tsx
@@ -72,7 +72,7 @@ const buildPath = (shape: TextLoopShape, curviness: number, ribbonWidth: number)
 };
 
 const TextLoop = ({
-  text = 'React ✦ Bits',
+  text = 'React Bits',
   shape = 'wave',
   path,
   speed = 90,
@@ -105,8 +105,22 @@ const TextLoop = ({
   const d = useMemo(() => path || buildPath(shape, curviness, ribbonWidth), [path, shape, curviness, ribbonWidth]);
 
   const unit = useMemo(() => {
-    const base = uppercase ? String(text).toUpperCase() : String(text);
-    const gap = separator ? `\u00A0${separator}\u00A0` : '\u00A0\u00A0\u00A0';
+    let base = String(text ?? '');
+    let sep = separator ?? '';
+    if (uppercase) {
+      base = base.toUpperCase();
+      sep = sep.toUpperCase();
+    }
+    if (sep) {
+      // Strip any separator glyphs already present in the text so each
+      // repetition is joined by exactly one separator. A duplicated glyph
+      // breaks the textLength/lengthAdjust fit on the SVG path in stricter
+      // browsers (e.g. Firefox) and a separator can land on top of a letter.
+      base = base.split(sep).join('').replace(/[\s\u00A0]+/g, ' ').trim();
+    } else {
+      base = base.replace(/[\s\u00A0]+/g, ' ').trim();
+    }
+    const gap = sep ? `\u00A0${sep}\u00A0` : '\u00A0\u00A0\u00A0';
     return `${base}${gap}`;
   }, [text, separator, uppercase]);
 


### PR DESCRIPTION
Fixes #1062

## Bug
TextLoop default props used text='React [star] Bits' with separator='[star]'. After uppercase the repeated unit became 'REACT [star] BITS[NBSP][star][NBSP]', i.e. two separators per repetition. The duplicated glyph breaks the textLength / lengthAdjust fit on the SVG path in stricter browsers (Firefox, wave shape), so a [star] can land on top of a letter (usually R of REACT).

## Fix
- Change default text from 'React [star] Bits' to 'React Bits' in all 4 variants, demo DEFAULT_PROPS/prop table, and usage example.
- Harden unit construction: strip any separator occurrences from base, collapse whitespace, trim, then append exactly one '[NBSP][sep][NBSP]' gap. Legacy text containing the separator now converges to the same correct output. Empty separator still falls back to 3x NBSP.
- Applied to: src/content/.../TextLoop.jsx, src/tailwind/.../TextLoop.jsx, src/ts-default/.../TextLoop.tsx, src/ts-tailwind/.../TextLoop.tsx, plus TextLoopDemo.jsx and textLoopCode.js.

## Review notes
- No API change; default rendering changes from 'REACT [star] BITS [star]' to 'REACT BITS [star]' per repetition (single separator, even rhythm).
- Custom text containing the separator is sanitized to one separator per unit per component contract ('Glyph placed between each repetition'). Whitespace is collapsed/trimmed to avoid double spacing at the junction.
- Separator case follows uppercase flag for visual consistency (no-op for glyphs like [star]).
- public/r registry JSONs intentionally untouched (generated artifacts, local jsrepo build shows only CRLF noise).

## Tests
- Repo has no unit test script (package.json: dev/build/lint/format only).
- Verified: node unit-logic script 7/7 PASS (default, legacy default, custom with/without sep inside, text==sep, whitespace collapse, empty sep; all produce exactly 1 sep, 0 when empty).
- Verified: npx tsc --noEmit PASS (0 errors).
- Verified: npx eslint on changed JS files PASS (0 errors); full npm run lint shows 33 pre-existing errors on main, none in TextLoop files.
- Verified: npm run registry:build PASS (684 items). Full vite build timed out locally (>120s, large site) with no related errors.