### PR TITLE
fixed decrypted text component - reference text was visible

### DIFF
--- a/src/content/TextAnimations/DecryptedText/DecryptedText.jsx
+++ b/src/content/TextAnimations/DecryptedText/DecryptedText.jsx
@@ -14,7 +14,8 @@ const styles = {
     margin: '-1px',
     overflow: 'hidden',
     clip: 'rect(0,0,0,0)',
-    border: 0
+    border: 0,
+    visibility: 'hidden'
   }
 };
 

--- a/src/ts-default/TextAnimations/DecryptedText/DecryptedText.tsx
+++ b/src/ts-default/TextAnimations/DecryptedText/DecryptedText.tsx
@@ -15,7 +15,8 @@ const styles = {
     margin: '-1px',
     overflow: 'hidden',
     clip: 'rect(0,0,0,0)',
-    border: 0
+    border: 0,
+    visibility: 'hidden' as const
   }
 };
 


### PR DESCRIPTION
## Description

Fixes an issue where the reference text in `DecryptedText` was visible in the UI.

## Changes

- Added `visibility: hidden` to the reference text styles.
- Applied the fix to both JavaScript and TypeScript implementations.
- Keeps the reference text in the DOM without displaying it visually.

## Testing

- Verified the fix in both component implementations.
- No automated tests were run.