### PR TITLE
fix(DecryptedText): hide sr-only reference text in tailwind variants (#1066)

### DIFF
--- a/src/tailwind/TextAnimations/DecryptedText/DecryptedText.jsx
+++ b/src/tailwind/TextAnimations/DecryptedText/DecryptedText.jsx
@@ -1,6 +1,21 @@
 import { useEffect, useState, useRef, useMemo, useCallback } from 'react';
 import { motion } from 'motion/react';
 
+const styles = {
+  srOnly: {
+    position: 'absolute',
+    width: '1px',
+    height: '1px',
+    padding: 0,
+    margin: '-1px',
+    overflow: 'hidden',
+    clip: 'rect(0,0,0,0)',
+    whiteSpace: 'nowrap',
+    border: 0,
+    visibility: 'hidden'
+  }
+};
+
 export default function DecryptedText({
   text,
   speed = 50,
@@ -351,7 +366,7 @@ export default function DecryptedText({
       {...animateProps}
       {...props}
     >
-      <span className="sr-only">{displayText}</span>
+      <span className="sr-only" style={styles.srOnly}>{displayText}</span>
 
       <span aria-hidden="true">
         {displayText.split('').map((char, index) => {

--- a/src/ts-tailwind/TextAnimations/DecryptedText/DecryptedText.tsx
+++ b/src/ts-tailwind/TextAnimations/DecryptedText/DecryptedText.tsx
@@ -2,6 +2,21 @@ import { useEffect, useState, useRef, useMemo, useCallback } from 'react';
 import { motion } from 'motion/react';
 import type { HTMLMotionProps } from 'motion/react';
 
+const styles = {
+  srOnly: {
+    position: 'absolute' as const,
+    width: '1px',
+    height: '1px',
+    padding: 0,
+    margin: '-1px',
+    overflow: 'hidden',
+    clip: 'rect(0,0,0,0)',
+    whiteSpace: 'nowrap' as const,
+    border: 0,
+    visibility: 'hidden' as const
+  }
+};
+
 interface DecryptedTextProps extends HTMLMotionProps<'span'> {
   text: string;
   speed?: number;
@@ -368,7 +383,7 @@ export default function DecryptedText({
       {...animateProps}
       {...props}
     >
-      <span className="sr-only">{displayText}</span>
+      <span className="sr-only" style={styles.srOnly}>{displayText}</span>
 
       <span aria-hidden="true">
         {displayText.split('').map((char, index) => {


### PR DESCRIPTION
Related to #1066 (completes #1067 across all 4 variants).

## Bug
The sr-only reference text in DecryptedText was visible. #1067 added visibility hidden to the CSS variants (src/content JS and src/ts-default TS), but the tailwind variants still relied solely on the sr-only utility class with no inline fallback, so the reference text stays visible when Tailwind is absent, purged, or copied standalone.

## Fix
- src/tailwind/TextAnimations/DecryptedText/DecryptedText.jsx and src/ts-tailwind/.../DecryptedText.tsx: added an inline styles.srOnly object with full screen-reader-only properties plus visibility hidden, and applied it as style on the sr-only span while keeping className sr-only for compatibility.
- All 4 variants now hide the reference text: content JS (done in #1067), ts-default (done in #1067), tailwind JS (this PR), ts-tailwind (this PR).
- public/r registry JSONs untouched (generated artifacts).

## Tests
- Repo has no unit test script (dev/build/lint/format only).
- npx tsc --noEmit PASS (0 errors).
- npx eslint on changed tailwind JSX file PASS (0 errors).
- Verified all 4 DecryptedText variants contain visibility hidden.